### PR TITLE
Accept host and port as CLI arguments when --serve is used

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,6 +15,9 @@ pub struct Cli {
     #[arg(long)]
     pub serve: bool,
 
+    #[arg(long, default_value = "localhost:8000")]
+    pub bind: String,
+
     /// Path to custom configuration file (defaults to marmite.yaml)
     #[arg(long, default_value = "marmite.yaml")]
     pub config: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ fn main() -> io::Result<()> {
     let serve = args.serve;
     let debug = args.debug;
     let config_path = input_folder.join(args.config);
+    let bind_address: &str = args.bind.as_str();
 
     // Initialize site data
     let marmite = fs::read_to_string(&config_path).unwrap_or_else(|e| {
@@ -129,7 +130,7 @@ fn main() -> io::Result<()> {
     // Serve the site if the flag was provided
     if serve {
         println!("Starting built-in HTTP server...");
-        server::start_server(output_folder.clone().into());
+        server::start_server(&bind_address, output_folder.clone().into());
     }
 
     println!("Site generated at: {}/", output_folder.display());

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,10 +4,13 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tiny_http::{Response, Server};
 
-pub fn start_server(output_folder: Arc<PathBuf>) {
-    let server = Server::http("localhost:8000").unwrap();
+pub fn start_server(bind_address: &str, output_folder: Arc<PathBuf>) {
+    let server = Server::http(bind_address).unwrap();
 
-    println!("Server started at http://localhost:8000/  - Type ^C to stop.");
+    println!(
+        "Server started at http://{}/ - Type ^C to stop.",
+        bind_address
+    );
 
     for request in server.incoming_requests() {
         let response = match handle_request(&request, &output_folder) {


### PR DESCRIPTION
Added the CLI entry for `--bind`

- Closes
   - #33 

![image](https://github.com/user-attachments/assets/291f6c21-1837-47ba-b50e-0242ac9699bf)
