### PR TITLE
chore: more messages on HTTP server

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -44,6 +44,12 @@ fn handle_request(
             Ok(mut file) => {
                 let mut buffer = Vec::new();
                 std::io::copy(&mut file, &mut buffer).map_err(|e| e.to_string())?;
+                info!(
+                    "\"{} {} HTTP/{}\" 200 -",
+                    request.method(),
+                    request_path,
+                    request.http_version()
+                );
                 Ok(Response::from_data(buffer))
             }
             Err(err) => {
@@ -52,7 +58,12 @@ fn handle_request(
             }
         }
     } else {
-        error!("File not found: {}", file_path.display());
+        error!(
+            "\"{} {} HTTP/{}\" 404 -",
+            request.method(),
+            request_path,
+            request.http_version()
+        );
         Ok(Response::from_string("404 Not Found").with_status_code(404))
     }
 }


### PR DESCRIPTION
```bash
[2024-10-22T09:50:26Z INFO  marmite] Starting built-in HTTP server...
[2024-10-22T09:50:26Z INFO  marmite::server] Server started at http://localhost:8000/ - Type ^C to stop.
[2024-10-22T09:50:28Z INFO  marmite::server] "GET index.html HTTP/1.1" 200 -
[2024-10-22T09:50:29Z INFO  marmite::server] "GET about.html HTTP/1.1" 200 -
[2024-10-22T09:50:32Z INFO  marmite::server] "GET index.html HTTP/1.1" 200 -
[2024-10-22T09:50:33Z INFO  marmite::server] "GET pages.html HTTP/1.1" 200 -
[2024-10-22T09:50:33Z INFO  marmite::server] "GET tags.html HTTP/1.1" 200 -
[2024-10-22T09:50:38Z ERROR marmite::server] "GET sdfsdfsd.html HTTP/1.1" 404 -
[2024-10-22T09:50:44Z ERROR marmite::server] "GET dfsfsdfsdfsdf.html HTTP/1.1" 404 -

```