### PR TITLE
Render page 404

### DIFF
--- a/example/content/404.md
+++ b/example/content/404.md
@@ -1,0 +1,5 @@
+---
+title: Page not found!
+---
+
+Page not found

--- a/example/content/404.md
+++ b/example/content/404.md
@@ -1,5 +1,5 @@
 ---
-title: Page not found!
+title: Page not found
 ---
 
-Page not found
+Page not found :/

--- a/example/templates/base.html
+++ b/example/templates/base.html
@@ -37,7 +37,7 @@
                 <ul class="header-menu" id="header-menu">
                     {% for item in menu %}
                     <li>
-                        {% if current_page == item.1 %}
+                        {% if current_page and current_page == item.1 %}
                         <button class="secondary">{{item.0 | safe }}</button>
                         {% else %}
                         <a href="{{ url_for(path=item.1) }}" class="secondary" {%if item.1 is starting_with("http") %}target="_blank"{% endif %}>{{ item.0 | safe }}</a>

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -5,7 +5,7 @@ use frontmatter_gen::{extract, Frontmatter};
 use std::fs;
 use std::path::Path;
 
-pub fn process_file(path: &Path, site_data: &mut Data) -> Result<(), String> {
+pub fn process_file(path: &Path, site_data: &mut Data, use_filename_as_slug: bool) -> Result<(), String> {
     let file_content = fs::read_to_string(path).map_err(|e| e.to_string())?;
     let (frontmatter, markdown) = parse_front_matter(&file_content)?;
     let mut options = ComrakOptions::default();
@@ -39,7 +39,13 @@ pub fn process_file(path: &Path, site_data: &mut Data) -> Result<(), String> {
 
     let title = get_title(&frontmatter, markdown);
     let tags = get_tags(&frontmatter);
-    let slug = get_slug(&frontmatter, path);
+    let slug = {
+        if use_filename_as_slug {
+            path.file_name().expect("Error on getting file name").to_str().expect("Error on converting file name to string").to_string().replace(".md", "")
+        } else {
+            get_slug(&frontmatter, path)
+        }
+    };
     let date = get_date(&frontmatter, path);
 
     let extra = frontmatter.get("extra").map(std::borrow::ToOwned::to_owned);

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -5,7 +5,11 @@ use frontmatter_gen::{extract, Frontmatter};
 use std::fs;
 use std::path::Path;
 
-pub fn process_file(path: &Path, site_data: &mut Data, use_filename_as_slug: bool) -> Result<(), String> {
+pub fn process_file(
+    path: &Path,
+    site_data: &mut Data,
+    use_filename_as_slug: bool,
+) -> Result<(), String> {
     let file_content = fs::read_to_string(path).map_err(|e| e.to_string())?;
     let (frontmatter, markdown) = parse_front_matter(&file_content)?;
     let mut options = ComrakOptions::default();
@@ -41,7 +45,12 @@ pub fn process_file(path: &Path, site_data: &mut Data, use_filename_as_slug: boo
     let tags = get_tags(&frontmatter);
     let slug = {
         if use_filename_as_slug {
-            path.file_name().expect("Error on getting file name").to_str().expect("Error on converting file name to string").to_string().replace(".md", "")
+            path.file_name()
+                .expect("Error on getting file name")
+                .to_str()
+                .expect("Error on converting file name to string")
+                .to_string()
+                .replace(".md", "")
         } else {
             get_slug(&frontmatter, path)
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -84,7 +84,7 @@ fn render_not_found(error_path: &PathBuf) -> Result<Response<Cursor<Vec<u8>>>, S
             Ok(resp)
         }
         Err(err) => {
-            error!("Error on generating page 404 - {}", err);
+            error!("Error on rendering page 404 - {}", err);
             Ok(Response::from_string("404 Not Found").with_status_code(404))
         }
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -39,6 +39,7 @@ fn handle_request(
     };
 
     let file_path = output_folder.join(request_path);
+    let error_path = output_folder.join("404.html");
 
     if file_path.is_file() {
         match File::open(&file_path) {
@@ -70,6 +71,21 @@ fn handle_request(
             request_path,
             request.http_version()
         );
-        Ok(Response::from_string("404 Not Found").with_status_code(404))
+        render_not_found(&error_path)
+    }
+}
+
+fn render_not_found(error_path: &PathBuf) -> Result<Response<Cursor<Vec<u8>>>, String> {
+    match File::open(&error_path) {
+        Ok(mut file) => {
+            let mut buffer = Vec::new();
+            std::io::copy(&mut file, &mut buffer).map_err(|e| e.to_string())?;
+            let resp = Response::from_data(buffer);
+            Ok(resp)
+        }
+        Err(err) => {
+            error!("Error on generating page 404 - {}", err);
+            Ok(Response::from_string("404 Not Found").with_status_code(404))
+        }
     }
 }

--- a/src/site.rs
+++ b/src/site.rs
@@ -109,7 +109,7 @@ fn render_templates(site_data: &Data, tera: &Tera, output_dir: &Path) -> Result<
             date: None,
             slug: String::from(""),
             extra: None,
-            tags: vec![]
+            tags: vec![],
         };
         content_context.insert("title", &page_404_content.title);
         content_context.insert("content", &page_404_content);
@@ -372,9 +372,15 @@ fn collect_content(content_dir: &std::path::PathBuf, site_data: &mut Data) {
         .into_iter()
         .filter_map(Result::ok)
         .filter(|e| {
-            let file_name = e.path().file_name().and_then(|ext| ext.to_str()).expect("Could not get file name");
+            let file_name = e
+                .path()
+                .file_name()
+                .and_then(|ext| ext.to_str())
+                .expect("Could not get file name");
             let file_extension = e.path().extension().and_then(|ext| ext.to_str());
-            e.path().is_file() && !NAME_BASED_SLUG_FILES.contains(&file_name) && file_extension == Some("md")
+            e.path().is_file()
+                && !NAME_BASED_SLUG_FILES.contains(&file_name)
+                && file_extension == Some("md")
         })
         .for_each(|entry| {
             if let Err(e) = process_file(entry.path(), site_data, false) {
@@ -382,14 +388,16 @@ fn collect_content(content_dir: &std::path::PathBuf, site_data: &mut Data) {
             }
         });
 
-        NAME_BASED_SLUG_FILES
-        .into_iter()
-        .for_each(|slugged_file| {
-            let slugged_path = content_dir.join(slugged_file);
-            if slugged_path.exists() {
-                if let Err(e) = process_file(slugged_path.as_path(), site_data, true) {
-                    error!("Failed to process file {}: {}", slugged_path.as_path().display(), e);
-                }
+    NAME_BASED_SLUG_FILES.into_iter().for_each(|slugged_file| {
+        let slugged_path = content_dir.join(slugged_file);
+        if slugged_path.exists() {
+            if let Err(e) = process_file(slugged_path.as_path(), site_data, true) {
+                error!(
+                    "Failed to process file {}: {}",
+                    slugged_path.as_path().display(),
+                    e
+                );
             }
-        })
+        }
+    })
 }


### PR DESCRIPTION
Add new rendering process to consider page 404 generation.

This generation is following a process to ignore _slug_ frontmatter for this page and use the proper _md_ name file to generate the html.

It also considers that page 404.md can be deleted and if it happen a default 404.html will be generated.

Closes #9