### PR TITLE
Add `--init-templates` and `--start-theme` Flags 

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,6 +19,7 @@ pub struct Cli {
     #[arg(long)]
     pub watch: bool,
 
+    /// Address to bind the server (defaults to localhost:8000)
     #[arg(long, default_value = "localhost:8000")]
     pub bind: String,
 
@@ -29,4 +30,12 @@ pub struct Cli {
     /// Print debug messages
     #[arg(long)]
     pub debug: bool,
+
+    /// Initialize templates in the project
+    #[arg(long)]
+    pub init_templates: bool,
+
+    /// Initialize a theme with templates and static assets
+    #[arg(long)]
+    pub start_theme: bool,
 }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,37 +1,42 @@
 use log::error;
 use std::fs;
 use std::path::PathBuf;
+use crate::embedded::{Templates, generate_static};
 
-/// Creates the `templates/` folder and base template file.
-pub fn initialize_templates(output_folder: &PathBuf) {
-    let templates_path = output_folder.join("templates");
+/// Creates the `templates/` folder and writes embedded templates to it.
+pub fn initialize_templates(input_folder: &PathBuf) {
+    let templates_path = input_folder.join("templates");
     if let Err(e) = fs::create_dir_all(&templates_path) {
         error!("Failed to create templates directory: {}", e);
         return;
     }
 
-    let base_template_path = templates_path.join("base.html");
-    if let Err(e) = fs::write(base_template_path, "<!-- Base HTML template -->") {
-        error!("Failed to create base template: {}", e);
+    for name in Templates::iter() {
+        if let Some(template) = Templates::get(name.as_ref()) {
+            if let Ok(template_str) = std::str::from_utf8(template.data.as_ref()) {
+                let template_path = templates_path.join(name.as_ref());
+                if let Err(e) = fs::write(&template_path, template_str) {
+                    error!("Failed to write template '{}': {}", name.as_ref(), e);
+                }
+            } else {
+                error!("Failed to parse template '{}' as UTF-8", name.as_ref());
+            }
+        } else {
+            error!("Template '{}' not found in embedded resources", name.as_ref());
+        }
     }
 }
 
-/// Creates the `static/` folder with basic placeholder files.
-pub fn initialize_theme_assets(output_folder: &PathBuf) {
-    let static_path = output_folder.join("static");
-    if let Err(e) = fs::create_dir_all(&static_path) {
-        error!("Failed to create static assets directory: {}", e);
-        return;
+/// Uses `generate_static` to populate the `static/` folder with embedded content.
+pub fn initialize_theme_assets(input_folder: &PathBuf) {
+    let static_path = input_folder.join("static");
+
+    if !static_path.exists() {
+        if let Err(e) = fs::create_dir_all(&static_path) {
+            error!("Failed to create static assets directory: {}", e);
+            return;
+        }
     }
 
-    let css_path = static_path.join("style.css");
-    let js_path = static_path.join("script.js");
-
-    if let Err(e) = fs::write(css_path, "/* Add your styles here */") {
-        error!("Failed to create CSS file: {}", e);
-    }
-
-    if let Err(e) = fs::write(js_path, "// Add your scripts here") {
-        error!("Failed to create JavaScript file: {}", e);
-    }
+    generate_static(&static_path);
 }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,0 +1,37 @@
+use log::error;
+use std::fs;
+use std::path::PathBuf;
+
+/// Creates the `templates/` folder and base template file.
+pub fn initialize_templates(output_folder: &PathBuf) {
+    let templates_path = output_folder.join("templates");
+    if let Err(e) = fs::create_dir_all(&templates_path) {
+        error!("Failed to create templates directory: {}", e);
+        return;
+    }
+
+    let base_template_path = templates_path.join("base.html");
+    if let Err(e) = fs::write(base_template_path, "<!-- Base HTML template -->") {
+        error!("Failed to create base template: {}", e);
+    }
+}
+
+/// Creates the `static/` folder with basic placeholder files.
+pub fn initialize_theme_assets(output_folder: &PathBuf) {
+    let static_path = output_folder.join("static");
+    if let Err(e) = fs::create_dir_all(&static_path) {
+        error!("Failed to create static assets directory: {}", e);
+        return;
+    }
+
+    let css_path = static_path.join("style.css");
+    let js_path = static_path.join("script.js");
+
+    if let Err(e) = fs::write(css_path, "/* Add your styles here */") {
+        error!("Failed to create CSS file: {}", e);
+    }
+
+    if let Err(e) = fs::write(js_path, "// Add your scripts here") {
+        error!("Failed to create JavaScript file: {}", e);
+    }
+}


### PR DESCRIPTION
This PR introduces two new flags, `--init-templates` and `--start-theme`, to the Marmite CLI, allowing users to initialize project templates and themes more easily. The new flags add the following functionality:

- **`--init-templates`**: Creates a `templates/` folder in the output directory, adding a `base.html` file as a starter template.
- **`--start-theme`**: Extends the `--init-templates` command by additionally creating a `static/` folder with placeholder files (`style.css`, `script.js`) referenced by the templates.

To support these new flags, two functions were added:
- **`initialize_templates`**: Sets up the `templates` directory and base files.
- **`initialize_theme_assets`**: Sets up the `static` assets directory and initial CSS/JS files.

Both functions are currently in a new module, `initializer.rs`, but they contain only placeholder code for now.

### Questions

Before proceeding with the complete implementation, we would like some input on how the `initialize_templates` and `initialize_theme_assets` functions should be implemented. Specifically:
1. **Template Content**: What content should be included in the `base.html` file within the `templates` folder? Should it be a full HTML skeleton, or just a simple comment indicating where customization can begin?
2. **Static Assets**: Should `style.css` and `script.js` in the `static/` folder include specific starter content, or can they be empty placeholders?


Related Issue : #70