### PR TITLE
Repeated title annoyance

### DIFF
--- a/example/templates/list.html
+++ b/example/templates/list.html
@@ -16,7 +16,7 @@
             {%- for content in content_list %}
             <article class="content-list-item">
                 <h2 class="content-title"><a href="./{{content.slug}}.html">{{ content.title | capitalize }}</a></h2>
-                <p class="content-excerpt">{{ content.html | striptags | truncate(length=100, end="...") }}</p>
+                <p class="content-excerpt">{{ content.html | striptags | truncate(length=100, end="...") | trim_start_matches(pat=content.title) }}</p>
                 {% if content.date -%}
                 <footer class="data-tags-footer">
                     <span class="content-date">{{ content.date | date(format="%b %e, %Y") }}</span>


### PR DESCRIPTION
This should fix the bug raised by #84 

![image](https://github.com/user-attachments/assets/492c5860-4251-4335-91b9-14eb934c864a)

I tryed to leave as a minimal change ... change could be done inside `site.rs` but was more convoluted given this would need to happen before Tera convert everything to html, but it would be problematic for the content. It would probably need a new property on the Struct just for that.

Closes:
 - #84 