### PR TITLE
Repeated title annoyance

### DIFF
--- a/example/templates/list.html
+++ b/example/templates/list.html
@@ -16,7 +16,7 @@
             {%- for content in content_list %}
             <article class="content-list-item">
                 <h2 class="content-title"><a href="./{{content.slug}}.html">{{ content.title | capitalize }}</a></h2>
-                <p class="content-excerpt">{{ content.html | striptags | truncate(length=100, end="...") | trim_start_matches(pat=content.title) }}</p>
+                <p class="content-excerpt">{{ content.html | striptags | trim_start_matches(pat=content.title) | truncate(length=100, end="...") }}</p>
                 {% if content.date -%}
                 <footer class="data-tags-footer">
                     <span class="content-date">{{ content.date | date(format="%b %e, %Y") }}</span>


### PR DESCRIPTION
Sorry, had to open a small fix for this ... I added the `trim_start_matches` at the end of the options, but probably would be better to become first and then truncate (just to keep the 100 chars correct).

Also, if you find it useful I create this branch which checks for a `description` field in the metadata of .md (just like title). I don't like because it needs to reprocess the html to get the description.

But ...
https://github.com/rochacbruno/marmite/compare/main...rdenadai:repeated-title-annoyance-complex?expand=1