### PR TITLE
Cards description

### DIFF
--- a/example/content/markdown-format.md
+++ b/example/content/markdown-format.md
@@ -2,6 +2,7 @@
 date: 2024-10-17 12:00:01
 slug: markdown-format
 title: Markdown Formatting Options
+description: The content here accepts any valid CommonMark or Github Flavoured markdown and some GFM extensions.
 tags: docs, markdown, Common Mark, GFM
 extra:
   math: true

--- a/example/templates/list.html
+++ b/example/templates/list.html
@@ -16,7 +16,13 @@
             {%- for content in content_list %}
             <article class="content-list-item">
                 <h2 class="content-title"><a href="./{{content.slug}}.html">{{ content.title | capitalize }}</a></h2>
-                <p class="content-excerpt">{{ content.html | striptags | trim_start_matches(pat=content.title) | truncate(length=100, end="...") }}</p>
+                <p class="content-excerpt">
+                    {% if content.description %}
+                        {{ content.description | replace(from='"', to="") | truncate(length=100, end="...") }}
+                    {% else %}
+                        {{ content.html | striptags | trim_start_matches(pat=content.title) | truncate(length=100, end="...") }}
+                    {%- endif %}
+                </p>
                 {% if content.date -%}
                 <footer class="data-tags-footer">
                     <span class="content-date">{{ content.date | date(format="%b %e, %Y") }}</span>

--- a/src/content.rs
+++ b/src/content.rs
@@ -12,6 +12,7 @@ use unicode_normalization::UnicodeNormalization;
 #[derive(Debug, Deserialize, Clone, Serialize)]
 pub struct Content {
     pub title: String,
+    pub description: Option<String>,
     pub slug: String,
     pub html: String,
     pub tags: Vec<String>,
@@ -30,6 +31,13 @@ pub fn get_title<'a>(frontmatter: &'a Frontmatter, html: &'a str) -> String {
             .trim()
             .to_string(),
     }
+}
+
+pub fn get_description<'a>(frontmatter: &'a Frontmatter) -> Option<String> {
+    if let Some(description) = frontmatter.get("description") {
+        return Some(description.to_string());
+    }
+    None
 }
 
 pub fn get_slug<'a>(frontmatter: &'a Frontmatter, path: &'a Path) -> String {

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -1,4 +1,4 @@
-use crate::content::{get_date, get_slug, get_tags, get_title, Content};
+use crate::content::{get_date, get_description, get_slug, get_tags, get_title, Content};
 use crate::site::Data;
 use comrak::{markdown_to_html, ComrakOptions};
 use frontmatter_gen::{extract, Frontmatter};
@@ -21,12 +21,14 @@ pub fn get_content(path: &Path) -> Result<Content, String> {
     let (frontmatter, markdown) = parse_front_matter(&file_content)?;
     let html = get_html(markdown);
     let title = get_title(&frontmatter, markdown);
+    let description = get_description(&frontmatter);
     let tags = get_tags(&frontmatter);
     let slug = get_slug(&frontmatter, path);
     let date = get_date(&frontmatter, path);
     let extra = frontmatter.get("extra").map(std::borrow::ToOwned::to_owned);
     let content = Content {
         title,
+        description,
         slug,
         html,
         tags,

--- a/src/site.rs
+++ b/src/site.rs
@@ -466,6 +466,7 @@ fn handle_404(
     let mut content = Content {
         html: String::from("Page not found :/"),
         title: String::from("Page not found"),
+        description: None,
         date: None,
         slug: "404".to_string(),
         extra: None,


### PR DESCRIPTION
@rochacbruno this an attempt to make it possible the `description` for the cards in the `list.html`.

I added a `description` to the `Content` struct, that could get filled with values in a `description`, if None we just fallback to the previous way (get from html and strip everything).