### PR TITLE
feat: add default date format

### DIFF
--- a/example/marmite.yaml
+++ b/example/marmite.yaml
@@ -1,4 +1,4 @@
-# name: My Blog
+name: My Blog
 # tagline: This blog is awesome
 # url: https://www.myblog.com/blog/
 # footer: This is an example site generated with Marmite
@@ -24,7 +24,7 @@ menu:
   - ["Archive", "archive.html"]
   - ["Github", "https://github.com/rochacbruno/marmite"]
 
-
+default_date_format: "%A, %d %B"
 # extra data for template customization
 # extra:
 #  foo: bar

--- a/example/templates/list.html
+++ b/example/templates/list.html
@@ -25,7 +25,7 @@
                 </p>
                 {% if content.date -%}
                 <footer class="data-tags-footer">
-                    <span class="content-date">{{ content.date | date(format="%b %e, %Y") }}</span>
+                    <span class="content-date">{{ content.date | default_date_format }}</span>
                     {% if content.tags -%}
                     <ul class="content-tags overflow-auto">
                         {% for tag in content.tags | slice(end=3) -%}

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,9 @@ pub struct Marmite {
     #[serde(default = "default_enable_search")]
     pub enable_search: bool,
 
+    #[serde(default = "default_date_format")]
+    pub default_date_format: String,
+
     #[serde(default = "default_menu")]
     pub menu: Option<Vec<(String, String)>>,
 
@@ -128,6 +131,10 @@ fn default_logo_image() -> String {
 
 fn default_enable_search() -> bool {
     false
+}
+
+fn default_date_format() -> String {
+    "%b %e, %Y".to_string()
 }
 
 fn default_menu() -> Option<Vec<(String, String)>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod markdown;
 mod server;
 mod site;
 mod templates;
+mod tera_filter;
 mod tera_functions;
 
 fn main() {

--- a/src/site.rs
+++ b/src/site.rs
@@ -2,8 +2,8 @@ use crate::config::Marmite;
 use crate::content::{check_for_duplicate_slugs, group_by_tags, slugify, Content};
 use crate::embedded::{generate_static, EMBEDDED_TERA};
 use crate::markdown::{get_content, process_file};
-use crate::{server, tera_filter};
 use crate::tera_functions::UrlFor;
+use crate::{server, tera_filter};
 use chrono::Datelike;
 use fs_extra::dir::{copy as dircopy, CopyOptions};
 use hotwatch::{Event, EventKind, Hotwatch};
@@ -245,8 +245,8 @@ fn initialize_tera(input_folder: &Path, site_data: &Data) -> Tera {
     );
     tera.register_filter(
         "default_date_format",
-        tera_filter::DefaultDateFormat{
-            date_format: site_data.site.default_date_format.to_string()
+        tera_filter::DefaultDateFormat {
+            date_format: site_data.site.default_date_format.to_string(),
         },
     );
     tera.extend(&EMBEDDED_TERA).unwrap();
@@ -428,7 +428,7 @@ fn generate_search_index(site_data: &Data, output_folder: &Arc<std::path::PathBu
         .join(site_data.site.static_path.clone())
         .join("search_index.json");
     if let Err(e) = fs::write(
-        &search_json_path,
+        search_json_path,
         serde_json::to_string(&all_content_json).unwrap(),
     ) {
         error!("Failed to write search_index.json: {}", e);

--- a/src/site.rs
+++ b/src/site.rs
@@ -2,7 +2,7 @@ use crate::config::Marmite;
 use crate::content::{check_for_duplicate_slugs, group_by_tags, slugify, Content};
 use crate::embedded::{generate_static, EMBEDDED_TERA};
 use crate::markdown::{get_content, process_file};
-use crate::server;
+use crate::{server, tera_filter};
 use crate::tera_functions::UrlFor;
 use chrono::Datelike;
 use fs_extra::dir::{copy as dircopy, CopyOptions};
@@ -241,6 +241,12 @@ fn initialize_tera(input_folder: &Path, site_data: &Data) -> Tera {
         "url_for",
         UrlFor {
             base_url: site_data.site.url.to_string(),
+        },
+    );
+    tera.register_filter(
+        "default_date_format",
+        tera_filter::DefaultDateFormat{
+            date_format: site_data.site.default_date_format.to_string()
         },
     );
     tera.extend(&EMBEDDED_TERA).unwrap();

--- a/src/tera_filter.rs
+++ b/src/tera_filter.rs
@@ -1,9 +1,9 @@
 use std::str::FromStr;
 
-use tera::{to_value, Filter, Tera};
+use tera::{to_value, Filter};
 
 pub struct DefaultDateFormat {
-    pub date_format: String
+    pub date_format: String,
 }
 
 impl Filter for DefaultDateFormat {
@@ -12,11 +12,13 @@ impl Filter for DefaultDateFormat {
         value: &tera::Value,
         _: &std::collections::HashMap<String, tera::Value>,
     ) -> tera::Result<tera::Value> {
-        let date_str = value.as_str().ok_or(tera::Error::msg("Missing date string"))?;
+        let date_str = value
+            .as_str()
+            .ok_or(tera::Error::msg("Missing date string"))?;
         let date = chrono::NaiveDateTime::from_str(date_str)
             .map_err(|e| tera::Error::msg(e.to_string()))?;
         let formatted_date = date.format(self.date_format.as_str()).to_string();
 
-        return to_value(formatted_date).map_err(tera::Error::from)
+        to_value(formatted_date).map_err(tera::Error::from)
     }
 }

--- a/src/tera_filter.rs
+++ b/src/tera_filter.rs
@@ -1,0 +1,22 @@
+use std::str::FromStr;
+
+use tera::{to_value, Filter, Tera};
+
+pub struct DefaultDateFormat {
+    pub date_format: String
+}
+
+impl Filter for DefaultDateFormat {
+    fn filter(
+        &self,
+        value: &tera::Value,
+        _: &std::collections::HashMap<String, tera::Value>,
+    ) -> tera::Result<tera::Value> {
+        let date_str = value.as_str().ok_or(tera::Error::msg("Missing date string"))?;
+        let date = chrono::NaiveDateTime::from_str(date_str)
+            .map_err(|e| tera::Error::msg(e.to_string()))?;
+        let formatted_date = date.format(self.date_format.as_str()).to_string();
+
+        return to_value(formatted_date).map_err(tera::Error::from)
+    }
+}


### PR DESCRIPTION
Addressing #82, I added a filter called `default_date_format` that allows users to add their default date format. The default date can be configured in `marmite.yaml` with key `default_date_format`.

This is my first contribution, any feedback is appreciated 