### PR TITLE
feat:allow  overriding any listing page via markdown

### DIFF
--- a/example/templates/base.html
+++ b/example/templates/base.html
@@ -53,7 +53,7 @@
                 <ul class="header-name">
                     <li>
                         <hgroup>
-                            <h2><a href="./index.html" class="contrast">{{ site.name }}</a></h2>
+                            <h2><a href="./" class="contrast">{{ site.name }}</a></h2>
                             {% if site.tagline %} <p>{{ site.tagline }}</p> {% endif %}
                         </hgroup>
                     </li>


### PR DESCRIPTION
render list pages from stream-1.html to stream-n.html

if a page named {stream}.md is found on content folder, this is considered the index ex: index.md, notes.md, pages.md, tags-foo.md

if that page is not found, renders a {stream}.html mirroring {stream}-1.html