### PR TITLE
feat: Add enable_related_content flag

### DIFF
--- a/.github/marmite.yaml
+++ b/.github/marmite.yaml
@@ -3,7 +3,6 @@ tagline: Static Site Generator
 url: https://rochacbruno.github.io/marmite
 pagination: 5
 enable_search: true
-enable_related_content: true
 toc: true
 json_feed: true
 menu: 

--- a/.github/marmite.yaml
+++ b/.github/marmite.yaml
@@ -3,6 +3,7 @@ tagline: Static Site Generator
 url: https://rochacbruno.github.io/marmite
 pagination: 5
 enable_search: true
+enable_related_content: true
 toc: true
 json_feed: true
 menu: 

--- a/example/content/2024-10-24-21-05-12-getting-started.md
+++ b/example/content/2024-10-24-21-05-12-getting-started.md
@@ -368,7 +368,6 @@ $ marmite myblog site \
   --pagination 20 \
   --toc true \
   --enable-search true \
-  --enable-related-content true \
   --colorscheme dracula \
   --language en \
   --footer "- <strong>CopyLeft</strong> -"
@@ -394,13 +393,13 @@ The content depends on which commenting system you choose and how it is configur
 Read more on [Enabling Comments] page to learn how to enable **Gisqus**, a
 commenting system based on Github discussions.
 
-## Enabling related content
+## Disabling related content
 
-To enable backlinks and related content for a post (via tags) you can use `--enable-related-content` flag
+To disable backlinks and related content for a post (via tags) you can use `--enable-related-content false` flag
 in CLI or add the following to your `marmite.yaml`.
 
 ```yaml
-enable_related_content: true
+enable_related_content: false
 ```
 
 

--- a/example/content/2024-10-24-21-05-12-getting-started.md
+++ b/example/content/2024-10-24-21-05-12-getting-started.md
@@ -368,6 +368,7 @@ $ marmite myblog site \
   --pagination 20 \
   --toc true \
   --enable-search true \
+  --enable-related-content true \
   --colorscheme dracula \
   --language en \
   --footer "- <strong>CopyLeft</strong> -"
@@ -392,6 +393,16 @@ The content depends on which commenting system you choose and how it is configur
 
 Read more on [Enabling Comments] page to learn how to enable **Gisqus**, a
 commenting system based on Github discussions.
+
+## Enabling related content
+
+To enable backlinks and related content for a post (via tags) you can use `--enable-related-content` flag
+in CLI or add the following to your `marmite.yaml`.
+
+```yaml
+enable_related_content: true
+```
+
 
 ## Enabling Search
 

--- a/example/content/2024-11-26-marmite-command-line-interface.md
+++ b/example/content/2024-11-26-marmite-command-line-interface.md
@@ -238,6 +238,8 @@ Options:
           Number of posts per page [default: 10 or value from config file]
       --enable-search <ENABLE_SEARCH>
           Enable search [default: false or from config file] [possible values: true, false]
+      --enable-related-content <ENABLE_RELATED_CONTENT>
+          Enable backlinks and related content for posts [default: false or from config file] [possible values: true, false]
       --content-path <CONTENT_PATH>
           Path for content subfolder [default: "content" or value from config file] this is the folder
           where markdown files are stored inside `input_folder` no need to change this if your markdown

--- a/example/content/2024-11-26-marmite-command-line-interface.md
+++ b/example/content/2024-11-26-marmite-command-line-interface.md
@@ -239,7 +239,7 @@ Options:
       --enable-search <ENABLE_SEARCH>
           Enable search [default: false or from config file] [possible values: true, false]
       --enable-related-content <ENABLE_RELATED_CONTENT>
-          Enable backlinks and related content for posts [default: false or from config file] [possible values: true, false]
+          Enable backlinks and related content for posts [default: true or from config file] [possible values: true, false]
       --content-path <CONTENT_PATH>
           Path for content subfolder [default: "content" or value from config file] this is the folder
           where markdown files are stored inside `input_folder` no need to change this if your markdown

--- a/example/marmite.yaml
+++ b/example/marmite.yaml
@@ -21,7 +21,6 @@ card_image: ./media/og_image.jpg
 logo_image: media/logo.png
 
 enable_search: true
-enable_related_content: true
 
 menu:
   # - ["About", "about.html"]

--- a/example/marmite.yaml
+++ b/example/marmite.yaml
@@ -21,6 +21,7 @@ card_image: ./media/og_image.jpg
 logo_image: media/logo.png
 
 enable_search: true
+enable_related_content: true
 
 menu:
   # - ["About", "about.html"]

--- a/example/templates/content.html
+++ b/example/templates/content.html
@@ -85,6 +85,7 @@
   {% endif %}
 </article>
 
+{% if site.enable_related_content %}
 {% if content.back_links %}
 <article>
   Back-links
@@ -113,6 +114,7 @@
     </ul>
   </article>
   {% endif %}
+{% endif %}
 {% endif %}
 
 {% if comments is defined %}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -121,6 +121,10 @@ pub struct Configuration {
     #[arg(long)]
     pub enable_search: Option<bool>,
 
+    /// Enable backlinks and related content for posts [default: false or from config file]
+    #[arg(long)]
+    pub enable_related_content: Option<bool>,
+
     /// Path for content subfolder [default: "content" or value from config file]
     /// this is the folder where markdown files are stored inside `input_folder`
     /// no need to change this if your markdown files are in `input_folder` directly

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -121,8 +121,8 @@ pub struct Configuration {
     #[arg(long)]
     pub enable_search: Option<bool>,
 
-    /// Enable backlinks and related content for posts [default: false or from config file]
-    #[arg(long)]
+    /// Enable backlinks and related content for posts [default: true or from config file]
+    #[arg(long, default_value = None)]
     pub enable_related_content: Option<bool>,
 
     /// Path for content subfolder [default: "content" or value from config file]

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,7 +55,7 @@ pub struct Marmite {
     #[serde(default)]
     pub enable_search: bool,
 
-    #[serde(default)]
+    #[serde(default = "default_enable_related_content")]
     pub enable_related_content: bool,
 
     #[serde(default = "default_search_title")]
@@ -295,4 +295,8 @@ fn default_search_title() -> String {
 
 fn default_language() -> String {
     "en".to_string()
+}
+
+fn default_enable_related_content() -> bool {
+    true
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,6 +55,9 @@ pub struct Marmite {
     #[serde(default)]
     pub enable_search: bool,
 
+    #[serde(default)]
+    pub enable_related_content: bool,
+
     #[serde(default = "default_search_title")]
     pub search_title: String,
 
@@ -145,6 +148,9 @@ impl Marmite {
         }
         if let Some(enable_search) = cli_args.configuration.enable_search {
             self.enable_search = enable_search;
+        }
+        if let Some(enable_related_content) = cli_args.configuration.enable_related_content {
+            self.enable_related_content = enable_related_content;
         }
         if let Some(toc) = cli_args.configuration.toc {
             self.toc = toc;


### PR DESCRIPTION
Add new flag to enable/disable related content and back links for a post.
Defaults to true.

For issue #192