### PR TITLE
feat: add markdown source publishing and linking

### DIFF
--- a/example/marmite.yaml
+++ b/example/marmite.yaml
@@ -52,6 +52,10 @@ authors:
     links:
       - ["Github", "https://github.com/karlamagueta"]
 
+# Markdown source publishing
+publish_md: true
+# source_repository: https://github.com/rochacbruno/marmite/tree/main/example/content
+
 # extra data for template customization
 extra:
   colorscheme_toggle: true

--- a/example/templates/content.html
+++ b/example/templates/content.html
@@ -81,6 +81,15 @@
         </ul>
       </div>
     </div>
+    
+    {% if site.publish_md or site.source_repository %}
+    <div class="content-source">
+      {% set source_url = source_link(content=content) %}
+      {% if source_url %}
+        <a href="{{ source_url }}" rel="nofollow">📄 View source</a>
+      {% endif %}
+    </div>
+    {% endif %}
   </footer>
   {% endif %}
 </article>

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -170,4 +170,12 @@ pub struct Configuration {
     /// Show next and previous links in posts [default: true or from config file]
     #[arg(long)]
     pub show_next_prev_links: Option<bool>,
+
+    /// Publish markdown source files alongside HTML [default: false or from config file]
+    #[arg(long)]
+    pub publish_md: Option<bool>,
+
+    /// Source repository URL to link to markdown files [default: None or from config file]
+    #[arg(long)]
+    pub source_repository: Option<String>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -109,6 +109,12 @@ pub struct Marmite {
 
     #[serde(default = "default_true")]
     pub show_next_prev_links: bool,
+
+    #[serde(default)]
+    pub publish_md: bool,
+
+    #[serde(default)]
+    pub source_repository: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -201,6 +207,12 @@ impl Marmite {
         }
         if let Some(show_next_prev_links) = cli_args.configuration.show_next_prev_links {
             self.show_next_prev_links = show_next_prev_links;
+        }
+        if let Some(publish_md) = cli_args.configuration.publish_md {
+            self.publish_md = publish_md;
+        }
+        if let Some(source_repository) = &cli_args.configuration.source_repository {
+            self.source_repository = Some(source_repository.clone());
         }
     }
 }

--- a/src/content.rs
+++ b/src/content.rs
@@ -95,6 +95,7 @@ pub struct Content {
     pub comments: Option<bool>,
     pub next: Option<Box<Content>>,
     pub previous: Option<Box<Content>>,
+    pub source_path: Option<std::path::PathBuf>,
 }
 
 impl Content {
@@ -187,6 +188,7 @@ impl Content {
             comments,
             next: None,
             previous: None,
+            source_path: Some(path.to_path_buf()),
         };
         Ok(content)
     }
@@ -211,6 +213,7 @@ pub struct ContentBuilder {
     pinned: Option<bool>,
     toc: Option<String>,
     comments: Option<bool>,
+    source_path: Option<std::path::PathBuf>,
 }
 
 #[allow(dead_code)]
@@ -298,6 +301,11 @@ impl ContentBuilder {
         self.comments = Some(comments);
         self
     }
+    
+    pub fn source_path(mut self, source_path: std::path::PathBuf) -> Self {
+        self.source_path = Some(source_path);
+        self
+    }
 
     pub fn build(self) -> Content {
         Content {
@@ -320,6 +328,7 @@ impl ContentBuilder {
             comments: self.comments,
             next: None,
             previous: None,
+            source_path: self.source_path,
         }
     }
 }

--- a/src/site.rs
+++ b/src/site.rs
@@ -3,7 +3,7 @@ use crate::content::{
     check_for_duplicate_slugs, slugify, Content, ContentBuilder, GroupedContent, Kind,
 };
 use crate::embedded::{generate_static, Templates, EMBEDDED_TERA};
-use crate::tera_functions::{Group, UrlFor};
+use crate::tera_functions::{Group, SourceLink, UrlFor};
 use crate::{server, tera_filter};
 use chrono::Datelike;
 use core::str;
@@ -190,6 +190,7 @@ pub fn generate(
                 "render_templates",
                 "handle_static_artifacts",
                 "generate_search_index",
+                "copy_markdown_sources",
             ]
             .par_iter()
             .for_each(|step| match *step {
@@ -219,6 +220,11 @@ pub fn generate(
                 "generate_search_index" => {
                     if site_data.site.enable_search {
                         generate_search_index(&site_data, &moved_output_folder);
+                    }
+                }
+                "copy_markdown_sources" => {
+                    if site_data.site.publish_md {
+                        copy_markdown_sources(&site_data, &content_folder, &output_path);
                     }
                 }
                 _ => {}
@@ -492,6 +498,12 @@ fn initialize_tera(input_folder: &Path, site_data: &Data) -> Tera {
     tera.register_function(
         "group",
         Group {
+            site_data: site_data.clone(),
+        },
+    );
+    tera.register_function(
+        "source_link",
+        SourceLink {
             site_data: site_data.clone(),
         },
     );
@@ -1000,6 +1012,38 @@ fn generate_search_index(site_data: &Data, output_folder: &Arc<std::path::PathBu
     } else {
         info!("Generated search_index.json");
     }
+}
+
+fn copy_markdown_sources(
+    site_data: &Data,
+    content_folder: &Path,
+    output_path: &Path,
+) {
+    site_data
+        .posts
+        .iter()
+        .chain(&site_data.pages)
+        .for_each(|content| {
+            if let Some(source_path) = &content.source_path {
+                let relative_path = source_path
+                    .strip_prefix(content_folder)
+                    .unwrap_or(source_path);
+                let dest_path = output_path.join(relative_path);
+                
+                if let Some(parent) = dest_path.parent() {
+                    if let Err(e) = fs::create_dir_all(parent) {
+                        error!("Failed to create directory for markdown source: {e:?}");
+                        return;
+                    }
+                }
+                
+                if let Err(e) = fs::copy(source_path, &dest_path) {
+                    error!("Failed to copy markdown source {}: {e:?}", source_path.display());
+                } else {
+                    info!("Copied markdown source to {}", dest_path.display());
+                }
+            }
+        });
 }
 
 fn write_build_info(


### PR DESCRIPTION
## Summary
- Implements issue #81 for markdown source publishing and linking
- Adds `publish_md` config option to copy markdown files to output directory  
- Adds `source_repository` config option to link to external repository
- Includes CLI arguments `--publish-md` and `--source-repository`

## Features
- **Repository links**: When `source_repository` is configured, links point to the external repository (e.g., GitHub)
- **Local links**: When only `publish_md` is enabled, links point to local .md files in the output directory
- **Smart behavior**: Repository links take precedence over local links when both are configured
- **Post-only**: Source links only appear on posts (content with dates), not on static pages
- **Visual indicator**: Links include 📄 emoji and "View source" text with `rel="nofollow"`

## Configuration Examples
```yaml
# Repository linking
publish_md: true
source_repository: https://github.com/user/repo/tree/main/content

# Local linking only  
publish_md: true
```

## Test plan
- [x] Test with repository URL configuration
- [x] Test with local-only configuration
- [x] Verify markdown files are copied to output directory
- [x] Confirm links only appear on posts, not pages
- [x] Test CLI argument overrides
- [x] Verify build succeeds without errors

🤖 Generated with [Claude Code](https://claude.ai/code)