### PR TITLE
feat: implement draft stream filtering for feeds and search

### DIFF
--- a/example/content/2024-07-20-draft-posts-guide.md
+++ b/example/content/2024-07-20-draft-posts-guide.md
@@ -1,0 +1,73 @@
+---
+title: "How to Use Draft Posts in Marmite"
+description: "Learn how to create draft posts that won't appear in feeds or search results"
+tags: ["documentation", "draft", "guide"]
+authors: ["marmite"]
+---
+
+# How to Use Draft Posts in Marmite
+
+Marmite supports draft posts that allow you to work on content without making it publicly discoverable through feeds or search. This guide explains how to create and manage draft posts.
+
+## Creating a Draft Post
+
+To mark a post as a draft, simply add `stream: draft` to your post's frontmatter:
+
+```markdown
+---
+title: "My Work in Progress Post"
+description: "This post is still being written"
+tags: ["example"]
+stream: draft
+authors: ["yourname"]
+---
+
+# My Draft Post
+
+This content is still being worked on and won't appear in feeds.
+```
+
+## What Happens to Draft Posts
+
+When you set a post's stream to "draft", the following behavior occurs:
+
+### ✅ What Still Works
+- **Individual HTML pages are generated** - You can still view the post directly by URL
+- **Draft stream page is created** - A `draft.html` page lists all draft posts
+- **All normal post processing** - Markdown rendering, template processing, etc.
+
+### ❌ What Gets Excluded
+- **RSS feeds** - Draft posts won't appear in `index.rss` or any other RSS feeds
+- **JSON feeds** - Draft posts won't appear in `index.json` or any other JSON feeds  
+- **Search index** - Draft posts won't be included in `search_index.json`
+- **Feed files for draft stream** - No `draft.rss` or `draft.json` files are generated
+
+## Use Cases for Draft Posts
+
+Draft posts are useful for:
+
+- **Work in progress content** - Write and preview posts before publishing
+- **Internal documentation** - Create content for your team that shouldn't be public
+- **Scheduled content** - Prepare posts in advance (remember to change the stream when ready to publish)
+- **Experimental content** - Test ideas without affecting your public feeds
+
+## Publishing a Draft Post
+
+To publish a draft post, simply:
+
+1. Remove the `stream: draft` line from the frontmatter, OR
+2. Change it to a different stream like `stream: blog` or `stream: news`
+
+The post will then appear in all feeds and search results on the next build.
+
+## Viewing Draft Posts
+
+Draft posts are still accessible if you know the URL:
+- Individual post: `yoursite.com/draft-post-title.html` 
+- Draft stream page: `yoursite.com/draft.html` (lists all draft posts)
+
+The draft stream page can be useful for reviewing all your unpublished content.
+
+## Security Note
+
+Remember that draft posts still generate HTML files that are publicly accessible if someone knows the URL. If you need truly private content, consider using a separate private repository or local development environment.

--- a/example/templates/base.html
+++ b/example/templates/base.html
@@ -33,7 +33,7 @@
     {%- block feeds %}
     <link rel="alternate" type="application/rss+xml" title="index" href="index.rss">
     {% for stream, _ in group(kind="stream") -%}
-    {% if stream == "index" %}{% continue %}{% endif %}
+    {% if stream == "index" or stream == "draft" %}{% continue %}{% endif %}
     <link rel="alternate" type="application/rss+xml" title="{{stream}}" href="{{stream | slugify}}.rss">
     {% endfor %}
     {%- for tag, _ in group(kind="tag") -%}
@@ -49,7 +49,7 @@
     {% if site.json_feed %}
     <link rel="alternate" type="application/feed+json" title="JSON index" href="index.json">
     {% for stream, _ in group(kind="stream") -%}
-    {% if stream == "index" %}{% continue %}{% endif %}
+    {% if stream == "index" or stream == "draft" %}{% continue %}{% endif %}
     <link rel="alternate" type="application/feed+json" title="JSON {{stream}}" href="{{stream | slugify}}.json">
     {% endfor %}
     {%- for tag, _ in group(kind="tag") -%}

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -34,7 +34,18 @@ pub fn generate_rss(
         .generator("marmite".to_string())
         .build();
 
-    for content in contents.iter().take(15) {
+    // Filter out content with stream "draft"
+    let filtered_contents: Vec<&Content> = contents
+        .iter()
+        .filter(|content| {
+            content
+                .stream
+                .as_ref()
+                .is_none_or(|stream| stream != "draft")
+        })
+        .collect();
+
+    for content in filtered_contents.iter().take(15) {
         let mut item = ItemBuilder::default()
             .title(content.title.clone())
             .link(format!("{}/{}.html", &feed_url, &content.slug))
@@ -136,7 +147,19 @@ pub fn generate_json(
 ) -> Result<(), String> {
     let date_format = "%Y-%m-%dT%H:%M:%S-00:00"; // Loose RFC3339 format
     let mut items = Vec::new();
-    for content in contents.iter().take(15) {
+
+    // Filter out content with stream "draft"
+    let filtered_contents: Vec<&Content> = contents
+        .iter()
+        .filter(|content| {
+            content
+                .stream
+                .as_ref()
+                .is_none_or(|stream| stream != "draft")
+        })
+        .collect();
+
+    for content in filtered_contents.iter().take(15) {
         let item = JsonFeedItem {
             id: format!("{}/{}.html", &config.url, &content.slug),
             url: format!("{}/{}.html", &config.url, &content.slug),

--- a/src/site.rs
+++ b/src/site.rs
@@ -985,10 +985,16 @@ fn generate_search_index(site_data: &Data, output_folder: &Arc<std::path::PathBu
         })
     };
 
-    // Merge posts and pages into a single list
+    // Merge posts and pages into a single list, filtering out draft content
     let all_content_json = site_data
         .posts
         .iter()
+        .filter(|content| {
+            content
+                .stream
+                .as_ref()
+                .is_none_or(|stream| stream != "draft")
+        })
         .map(convert_items_to_json)
         .collect::<Vec<_>>()
         .into_iter()
@@ -996,6 +1002,12 @@ fn generate_search_index(site_data: &Data, output_folder: &Arc<std::path::PathBu
             site_data
                 .pages
                 .iter()
+                .filter(|content| {
+                    content
+                        .stream
+                        .as_ref()
+                        .is_none_or(|stream| stream != "draft")
+                })
                 .map(convert_items_to_json)
                 .collect::<Vec<_>>(),
         )

--- a/src/site.rs
+++ b/src/site.rs
@@ -705,16 +705,25 @@ fn handle_stream_pages(
                 output_dir,
                 &stream_slug,
             )?;
-            // Render {stream}.rss for each stream
-            crate::feed::generate_rss(stream_contents, output_dir, &stream_slug, &site_data.site)?;
 
-            if site_data.site.json_feed {
-                crate::feed::generate_json(
+            // Skip generating feeds for draft stream
+            if *stream != "draft" {
+                // Render {stream}.rss for each stream
+                crate::feed::generate_rss(
                     stream_contents,
                     output_dir,
                     &stream_slug,
                     &site_data.site,
                 )?;
+
+                if site_data.site.json_feed {
+                    crate::feed::generate_json(
+                        stream_contents,
+                        output_dir,
+                        &stream_slug,
+                        &site_data.site,
+                    )?;
+                }
             }
             Ok(())
         })


### PR DESCRIPTION
## Summary
- Filter out content with `stream: draft` from RSS feeds, JSON feeds, and search index
- Prevent generation of `draft.rss` and `draft.json` files entirely  
- Remove draft feed links from HTML templates to avoid broken links
- Add comprehensive documentation on using draft posts

## Changes Made

### Core Filtering (`src/feed.rs`)
- Modified `generate_rss()` to filter out draft content using `is_none_or()`
- Modified `generate_json()` to filter out draft content using `is_none_or()`

### Search Index Filtering (`src/site.rs`) 
- Modified `generate_search_index()` to exclude draft content from both posts and pages
- Modified `handle_stream_pages()` to skip feed generation for "draft" stream

### Template Updates (`example/templates/base.html`)
- Added condition to exclude "draft" from RSS and JSON feed link generation
- Prevents broken links to non-existent draft feed files

### Documentation (`example/content/2024-07-20-draft-posts-guide.md`)
- Comprehensive guide explaining draft post functionality
- Use cases, behavior, and publishing workflow
- Security considerations for draft content

## Test Plan
- [x] Created test draft content with `stream: draft`
- [x] Verified draft content excluded from `index.rss`, `index.json`, `search_index.json`
- [x] Verified `draft.rss` and `draft.json` files are not generated
- [x] Verified draft HTML pages still generated for direct access
- [x] Verified other stream feeds work normally 
- [x] Verified feed links removed from main HTML pages
- [x] All formatting and clippy checks pass

## Behavior

### ✅ What Works
- Draft posts excluded from all RSS and JSON feeds
- Draft posts excluded from search index
- Draft HTML pages still generated and accessible by direct URL
- Draft stream page (`draft.html`) lists all draft posts
- All other streams and feeds work normally

### ❌ What's Excluded  
- No `draft.rss` or `draft.json` files created
- No draft content in main feeds or search
- No broken feed links in HTML templates

Closes #296

🤖 Generated with [Claude Code](https://claude.ai/code)