### PR TITLE
feat: update ureq dependency to 3.0.12 and fix image provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,6 +840,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1798,6 +1815,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2384,18 +2410,32 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
+version = "3.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+checksum = "9f0fde9bc91026e381155f8c67cb354bcd35260b2f4a29bcc84639f762760c39"
 dependencies = [
  "base64",
  "flate2",
  "log",
- "once_cell",
+ "percent-encoding",
  "rustls",
+ "rustls-pemfile",
  "rustls-pki-types",
- "url",
+ "ureq-proto",
+ "utf-8",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59db78ad1923f2b1be62b6da81fe80b173605ca0d57f85da2e005382adf693f7"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
 ]
 
 [[package]]
@@ -2408,6 +2448,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf16_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ lazy_static = "1.5.0"
 indexmap = { version = "2.10.0", features = ["serde"] }
 rss = "2.0.12"
 rayon = "1.10.0"
-ureq = "2.12"
+ureq = "3.0.12"
 
 [profile.release]
 codegen-units = 1

--- a/src/image_provider.rs
+++ b/src/image_provider.rs
@@ -63,7 +63,8 @@ fn download_picsum_image(
 
     if response.status() == 200 {
         let mut file = fs::File::create(&banner_file)?;
-        std::io::copy(&mut response.into_reader(), &mut file)?;
+        let mut body = response.into_body();
+        std::io::copy(&mut body.as_reader(), &mut file)?;
         info!("Downloaded banner image to: {}", banner_file.display());
     } else {
         warn!("Failed to download image: HTTP {}", response.status());


### PR DESCRIPTION
## Summary
- Updates ureq dependency from 2.12 to 3.0.12 for latest security fixes and improvements
- Fixes breaking API change in image_provider.rs due to ureq 3.x API changes
- Replaces deprecated `response.into_reader()` with `response.into_body().as_reader()`

## Changes
- **Cargo.toml**: Bump ureq version to 3.0.12
- **src/image_provider.rs**: Update HTTP response reading to use new ureq 3.x API
- **Cargo.lock**: Updated dependencies

## Test plan
- [x] All existing unit tests pass (75 tests)
- [x] Code quality checks pass (`mask check`)
- [x] Image provider functionality verified with live test
- [x] Downloaded test image (49KB JPEG, 1200x300px) successfully
- [x] Image correctly integrated in generated HTML (OpenGraph, JSON-LD, CSS)

🤖 Generated with [Claude Code](https://claude.ai/code)