### PR TITLE
feat: add link checking with lychee integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,9 +1160,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libm"
@@ -2017,9 +2017,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",

--- a/example/content/2024-11-26-marmite-command-line-interface.md
+++ b/example/content/2024-11-26-marmite-command-line-interface.md
@@ -217,6 +217,50 @@ image_provider: picsum
 
 Read more in the [[Automatic Image Download]] guide.
 
+## Link Checking
+
+Marmite includes built-in link checking functionality using [Lychee](https://lychee.cli.rs/),
+which helps ensure all links in your generated website are valid.
+
+### Enable link checking
+
+Use `--check-links` to check all links after building your site:
+
+```console
+$ marmite myblog output/ --check-links
+Site generated at: output/
+Starting temporary HTTP server for link checking...
+Starting link checking with Lychee...
+Link checking completed successfully!
+```
+
+This will:
+1. Build your static site 
+2. Start a temporary HTTP server (automatically enables `--serve`)
+3. Scan all HTML files for links using Lychee
+4. Check each link for validity
+5. Report any broken links and exit with error code if found
+
+### Requirements
+
+Link checking requires the Lychee binary to be installed:
+
+```console
+$ cargo install lychee
+```
+
+If Lychee is not available, Marmite will display a warning and skip link checking.
+
+### CI/CD Integration
+
+Perfect for automated deployments - the command exits with status code 1 if broken links are found:
+
+```console
+$ marmite myblog dist/ --check-links
+# Exit code 0: All links valid
+# Exit code 1: Broken links found
+```
+
 ## Markdown Source Publishing
 
 Marmite can publish the original markdown source files alongside your HTML content,
@@ -292,6 +336,9 @@ Options:
           Init a new site with sample content and default configuration this will overwrite existing files
           usually you don't need to run this because Marmite can generate a site from any folder with
           markdown files
+      --check-links
+          Check all links in the generated website using Lychee This option automatically enables
+          --serve to allow internal link checking
       --new <NEW>
           Create a new post with the given title and open in the default editor
   -e

--- a/example/content/2025-07-21-link-checking.md
+++ b/example/content/2025-07-21-link-checking.md
@@ -1,0 +1,83 @@
+---
+title: "Link Checking with Lychee Integration"
+date: 2025-07-21
+author: marmite
+tags: [docs, features, lychee, link-checking]
+stream: alt
+---
+
+Marmite now includes built-in link checking functionality using [Lychee](https://lychee.cli.rs/), a fast, async link checker written in Rust.
+
+## Using Link Checking
+
+To check all links in your generated website, use the `--check-links` flag:
+
+```bash
+marmite input_folder output_folder --check-links
+```
+
+This will:
+1. Build your static site
+2. Start a temporary HTTP server (automatically enables `--serve`)
+3. Scan all HTML files for links
+4. Check each link for validity
+5. Report any broken links and exit with an error code if found
+
+## How It Works
+
+When you use `--check-links`, Marmite automatically:
+- Enables the built-in HTTP server to allow internal link checking
+- Calls the Lychee binary to perform comprehensive link checking
+- Checks both internal and external links
+- Provides detailed reports about link status
+
+## Requirements
+
+The link checking feature requires the Lychee binary to be installed:
+
+```bash
+cargo install lychee
+```
+
+If Lychee is not installed, Marmite will display a warning and skip the link checking step gracefully.
+
+## Link Checking Results
+
+Lychee provides detailed information about each link:
+- ✓ Successful links
+- ↳ Redirected links (warnings)
+- ✗ Broken links (errors)
+- - Excluded links
+- ? Unsupported or unknown status links
+
+## Exit Codes
+
+- **0**: All links are working correctly
+- **1**: Broken links were found or link checking failed
+
+This makes it perfect for CI/CD pipelines where you want to ensure all links are valid before deploying your site.
+
+## Example Usage
+
+```bash
+# Basic link checking
+marmite example ./example/public --check-links
+
+# Link checking with custom bind address
+marmite example ./example/public --check-links --bind 127.0.0.1:3000
+
+# Watch mode with link checking (checks on each rebuild)
+marmite example ./example/public --check-links --watch
+```
+
+## Integration with CI/CD
+
+You can use this feature in your CI/CD pipeline to prevent broken links from being deployed:
+
+```yaml
+# GitHub Actions example
+- name: Build and check links
+  run: marmite . ./dist --check-links
+```
+
+The command will exit with status code 1 if any broken links are found, causing the CI/CD pipeline to fail.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -63,6 +63,11 @@ pub struct Cli {
     #[arg(long)]
     pub force: bool,
 
+    /// Check all links in the generated website using Lychee
+    /// This option automatically enables --serve to allow internal link checking
+    #[arg(long)]
+    pub check_links: bool,
+
     /// Create a new markdown file in the input folder
     #[command(flatten)]
     pub create: Create,

--- a/src/linkcheck.rs
+++ b/src/linkcheck.rs
@@ -26,7 +26,7 @@ pub fn check_links(output_folder: &Path, base_url: &str) -> Result<(), Box<dyn s
         cmd.arg("--base").arg(base_url);
     }
 
-    info!("Running: {:?}", cmd);
+    info!("Running: {cmd:?}");
 
     let output = cmd.output()?;
 

--- a/src/linkcheck.rs
+++ b/src/linkcheck.rs
@@ -1,0 +1,49 @@
+use log::{error, info, warn};
+use std::path::Path;
+use std::process::Command;
+
+/// Check all links in the generated website using Lychee binary
+pub fn check_links(output_folder: &Path, base_url: &str) -> Result<(), Box<dyn std::error::Error>> {
+    info!("Starting link checking with Lychee...");
+
+    // Check if lychee is available
+    if !is_lychee_installed() {
+        warn!("Lychee is not installed. Install it with: cargo install lychee");
+        warn!("Skipping link checking...");
+        return Ok(());
+    }
+
+    // Run lychee on the output folder
+    let mut cmd = Command::new("lychee");
+    cmd.arg("--verbose")
+        .arg("--no-progress")
+        .arg("--format")
+        .arg("json")
+        .arg(format!("{}/**/*.html", output_folder.display()));
+
+    // Add base URL to check internal links
+    if !base_url.is_empty() {
+        cmd.arg("--base").arg(base_url);
+    }
+
+    info!("Running: {:?}", cmd);
+
+    let output = cmd.output()?;
+
+    if output.status.success() {
+        info!("Link checking completed successfully!");
+        info!("Output: {}", String::from_utf8_lossy(&output.stdout));
+    } else {
+        error!("Link checking found broken links!");
+        error!("Error output: {}", String::from_utf8_lossy(&output.stderr));
+        error!("Output: {}", String::from_utf8_lossy(&output.stdout));
+        return Err("Link checking failed with broken links".into());
+    }
+
+    Ok(())
+}
+
+/// Check if lychee binary is installed
+fn is_lychee_installed() -> bool {
+    Command::new("lychee").arg("--version").output().is_ok()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,12 +125,12 @@ fn main() {
                 bind_address.split(':').nth(1).unwrap_or("8000")
             )
         } else {
-            format!("http://{}", bind_address)
+            format!("http://{bind_address}")
         };
 
         // Check links
         if let Err(e) = linkcheck::check_links(&output_folder, &base_url) {
-            error!("Link checking failed: {}", e);
+            error!("Link checking failed: {e}");
             std::process::exit(1);
         }
 


### PR DESCRIPTION
## Summary

Adds comprehensive link checking functionality using Lychee integration to validate all links in generated websites.

### Key Features

- **New CLI Option**: `--check-links` flag for link validation
- **Auto-serve Integration**: Automatically enables `--serve` for internal link checking  
- **Lychee Integration**: Uses the fast, async Lychee link checker
- **CI/CD Ready**: Proper exit codes (0 = success, 1 = broken links)
- **Graceful Fallback**: Works without Lychee installed (shows warning)
- **Watch Mode Compatible**: Works with `--watch` for continuous checking

### Usage

```bash
# Basic link checking
marmite input_folder output_folder --check-links

# With custom bind address  
marmite input_folder output_folder --check-links --bind 127.0.0.1:3000

# Watch mode with link checking
marmite input_folder output_folder --check-links --watch
```

### Implementation Details

- Added `--check-links` CLI option in `cli.rs`
- Created `linkcheck.rs` module with Lychee binary integration
- Modified `main.rs` to handle link checking workflow
- Added comprehensive documentation and examples
- Follows all project conventions and coding standards

### Test plan

- [x] Builds successfully with `cargo build`
- [x] Passes all checks with `mask check` 
- [x] CLI help shows new `--check-links` option
- [x] Feature works with example site (graceful fallback when Lychee not installed)
- [x] Documentation added to example content
- [x] Follows conventional commit format

🤖 Generated with [Claude Code](https://claude.ai/code)