### PR TITLE
feat: implement Series feature for grouping related content

### DIFF
--- a/example/content/2024-10-30-python-tutorial-part-1.md
+++ b/example/content/2024-10-30-python-tutorial-part-1.md
@@ -1,0 +1,35 @@
+---
+title: "Python Tutorial - Part 1: Getting Started"
+date: 2024-10-30
+series: python-tutorial
+stream: tutorial
+tags: ["python", "tutorial", "programming"]
+authors: ["marmite"]
+description: "First part of our comprehensive Python tutorial series covering the basics"
+---
+
+# Python Tutorial - Part 1: Getting Started
+
+Welcome to our comprehensive Python tutorial series! In this first part, we'll cover the basics of getting started with Python.
+
+## What is Python?
+
+Python is a high-level, interpreted programming language known for its simplicity and readability. It's an excellent choice for beginners and experienced programmers alike.
+
+## Installing Python
+
+To get started with Python, you'll need to install it on your system...
+
+## Your First Python Program
+
+Let's write our first Python program:
+
+```python
+print("Hello, World!")
+```
+
+This simple program demonstrates the basic syntax of Python.
+
+## What's Next?
+
+In the next part of this series, we'll explore Python data types and variables in detail.

--- a/example/content/2024-11-05-python-tutorial-part-2.md
+++ b/example/content/2024-11-05-python-tutorial-part-2.md
@@ -1,0 +1,67 @@
+---
+title: "Python Tutorial - Part 2: Data Types and Variables"
+date: 2024-11-05
+series: python-tutorial
+stream: tutorial
+tags: ["python", "tutorial", "programming", "data-types"]
+authors: ["marmite"]
+description: "Second part of our Python tutorial series focusing on data types and variables"
+---
+
+# Python Tutorial - Part 2: Data Types and Variables
+
+Welcome back to our Python tutorial series! In this second part, we'll explore Python's built-in data types and how to work with variables.
+
+## Python Variables
+
+Variables in Python are used to store data values. Unlike many other programming languages, Python has no command for declaring a variable.
+
+```python
+name = "Alice"
+age = 25
+height = 5.6
+```
+
+## Basic Data Types
+
+Python has several built-in data types:
+
+### Numbers
+- **int**: Integer numbers (e.g., 42, -17)
+- **float**: Decimal numbers (e.g., 3.14, -0.5)
+
+```python
+integer_number = 42
+floating_number = 3.14159
+```
+
+### Strings
+Text data is represented as strings in Python.
+
+```python
+greeting = "Hello, World!"
+multiline_text = """This is a
+multiline string"""
+```
+
+### Booleans
+Boolean values represent True or False.
+
+```python
+is_python_fun = True
+is_difficult = False
+```
+
+## Type Checking
+
+You can check the type of any variable using the `type()` function:
+
+```python
+print(type(42))        # <class 'int'>
+print(type(3.14))      # <class 'float'>
+print(type("Hello"))   # <class 'str'>
+```
+
+## What's Next?
+
+In Part 3, we'll dive into Python collections: lists, tuples, and dictionaries. These are fundamental data structures you'll use constantly in Python programming.

--- a/example/content/2024-11-12-python-tutorial-part-3.md
+++ b/example/content/2024-11-12-python-tutorial-part-3.md
@@ -1,0 +1,90 @@
+---
+title: "Python Tutorial - Part 3: Collections and Data Structures"
+date: 2024-11-12
+series: python-tutorial
+stream: tutorial
+tags: ["python", "tutorial", "programming", "collections", "data-structures"]
+authors: ["marmite"]
+description: "Third part of our Python tutorial series covering lists, tuples, and dictionaries"
+---
+
+# Python Tutorial - Part 3: Collections and Data Structures
+
+In this third installment of our Python tutorial series, we'll explore Python's built-in collection types that allow you to store and organize multiple pieces of data.
+
+## Lists
+
+Lists are ordered collections of items that can be changed (mutable).
+
+```python
+fruits = ["apple", "banana", "orange"]
+numbers = [1, 2, 3, 4, 5]
+mixed_list = ["hello", 42, 3.14, True]
+
+# Accessing elements
+print(fruits[0])  # "apple"
+print(fruits[-1]) # "orange" (last element)
+
+# Adding elements
+fruits.append("grape")
+```
+
+## Tuples
+
+Tuples are ordered collections that cannot be changed (immutable).
+
+```python
+coordinates = (10, 20)
+colors = ("red", "green", "blue")
+
+# Accessing elements (same as lists)
+print(coordinates[0])  # 10
+
+# Tuples are immutable - this would cause an error:
+# coordinates[0] = 15  # TypeError!
+```
+
+## Dictionaries
+
+Dictionaries store data in key-value pairs.
+
+```python
+person = {
+    "name": "Alice",
+    "age": 25,
+    "city": "New York"
+}
+
+# Accessing values
+print(person["name"])     # "Alice"
+print(person.get("age"))  # 25
+
+# Adding new key-value pairs
+person["job"] = "Developer"
+```
+
+## Working with Collections
+
+### Iterating through collections
+
+```python
+# Lists and tuples
+for fruit in fruits:
+    print(fruit)
+
+# Dictionaries
+for key, value in person.items():
+    print(f"{key}: {value}")
+```
+
+### Length and membership
+
+```python
+print(len(fruits))           # Number of items
+print("apple" in fruits)     # Check if item exists
+print("name" in person)      # Check if key exists
+```
+
+## What's Next?
+
+In Part 4, we'll learn about control flow: if statements, loops, and functions. These are the building blocks that make your Python programs dynamic and interactive!

--- a/example/content/2025-01-22-series-feature.md
+++ b/example/content/2025-01-22-series-feature.md
@@ -1,0 +1,226 @@
+---
+title: "Organizing Content with Series in Marmite"
+date: 2025-07-22
+tags: ["docs", "features", "content-organization", "series"]
+authors: ["rochacbruno"]
+description: "Learn how to organize related content into chronological series with Marmite's new Series feature"
+---
+
+# Organizing Content with Series in Marmite
+
+Marmite now supports **Series** - a powerful feature for organizing related content into chronological sequences. Perfect for tutorials, guides, or any multi-part content that should be read in order.
+
+## What are Series?
+
+Series allow you to group related posts together with automatic chronological ordering and navigation. Unlike tags or streams, series content is always ordered from oldest to newest, making them ideal for:
+
+- **Tutorial series** (like step-by-step guides)
+- **Course content** (progressive learning materials)
+- **Multi-part articles** (book chapters, long-form content)
+- **Sequential documentation** (installation → configuration → usage)
+
+## Basic Usage
+
+### Adding Content to a Series
+
+Simply add a `series` field to your content's frontmatter:
+
+```yaml
+---
+title: "Python Tutorial - Part 1: Getting Started"
+date: 2024-10-30
+series: python-tutorial
+tags: ["python", "tutorial", "programming"]
+authors: ["marmite"]
+description: "First part of our comprehensive Python tutorial series"
+---
+```
+
+### Series Naming Conventions
+
+- Use lowercase, hyphenated names: `python-tutorial`, `web-development-basics`
+- Keep names descriptive but concise
+- Use consistent naming across all parts of the series
+
+### Combining Series with Streams
+
+Series can be used in combination with streams for advanced content organization:
+
+```yaml
+---
+title: "Python Tutorial - Part 1: Getting Started"
+date: 2024-10-30
+series: python-tutorial
+stream: tutorial
+tags: ["python", "tutorial", "programming"]
+authors: ["marmite"]
+description: "First part of our comprehensive Python tutorial series"
+---
+```
+
+When both `series` and `stream` are set:
+- **Series navigation takes precedence** - next/previous links follow series order
+- **Content appears in stream feeds** - but maintains series chronological order
+- **Flexible visibility control** - use streams to exclude series content from main blog listing while keeping it organized in dedicated stream pages
+
+## Generated Pages
+
+Marmite automatically generates several pages for your series:
+
+### Individual Series Pages
+Each series gets its own page at `serie-{series-name}.html` showing all posts in chronological order (oldest to newest).
+
+### Series Index Page
+A master `series.html` page lists all available series with post counts and links.
+
+### RSS/JSON Feeds
+Each series automatically generates:
+- `serie-{series-name}.rss` - RSS feed for the series
+- `serie-{series-name}.json` - JSON feed for the series
+
+## Configuration
+
+### Series Display Names
+
+Configure friendly display names in `marmite.yaml`:
+
+```yaml
+series:
+  python-tutorial:
+    display_name: "Python Tutorial"
+    description: "A comprehensive Python programming tutorial series"
+  web-dev-basics:
+    display_name: "Web Development Basics"
+    description: "Essential skills for modern web development"
+```
+
+### Adding Series to Navigation
+
+Add series to your site navigation:
+
+```yaml
+menu:
+  - ["Pages", "pages.html"]
+  - ["Tags", "tags.html"] 
+  - ["Archive", "archive.html"]
+  - ["Authors", "authors.html"]
+  - ["Streams", "streams.html"]
+  - ["Series", "series.html"]  # Add this line
+```
+
+## Template Features
+
+### Series Information Display
+
+Content that's part of a series automatically shows:
+- A series link at the top: "Published as part of 'Python Tutorial' series."
+- No related content section (series navigation takes precedence)
+
+### Navigation Behavior
+
+Series content gets special navigation treatment:
+
+- **Next/Previous links** follow series chronology instead of publication date
+- **Series order** takes precedence over stream navigation
+- **Chronological flow** ensures readers follow the intended sequence
+
+## Template Functions
+
+### Series Display Name Function
+
+Use `series_display_name()` in templates:
+
+```html
+<!-- Shows configured display name or falls back to series name -->
+{{ series_display_name(series=content.series) }}
+```
+
+### Accessing Series Data
+
+In templates, access series information:
+
+```html
+{% if content.series %}
+  <p>Part of the <a href="{{ url_for(path='serie-' ~ content.series ~ '.html') }}">
+    {{ series_display_name(series=content.series) }}
+  </a> series</p>
+{% endif %}
+```
+
+## Best Practices
+
+### Content Organization
+
+1. **Plan your series structure** before creating content
+2. **Use consistent dating** to ensure proper ordering
+3. **Write clear descriptions** for each series part
+4. **Cross-reference related series** when appropriate
+
+### SEO Considerations
+
+- Each series page gets proper meta tags and structured data
+- Series RSS feeds improve content discoverability
+- Chronological navigation helps search engines understand content relationships
+
+### User Experience
+
+- **Clear series indicators** help readers understand they're in a sequence
+- **Consistent numbering** in titles (Part 1, Part 2, etc.)
+- **Series completion indicators** in descriptions when finished
+
+## Example: Complete Series Setup
+
+Here's how to set up a complete tutorial series:
+
+**Configuration** (`marmite.yaml`):
+```yaml
+series:
+  python-tutorial:
+    display_name: "Python Programming Tutorial"
+    description: "Learn Python from basics to advanced concepts"
+```
+
+**Content files**:
+```markdown
+# 2024-10-30-python-tutorial-part-1.md
+---
+title: "Python Tutorial - Part 1: Getting Started"
+date: 2024-10-30
+series: python-tutorial
+tags: ["python", "tutorial", "programming"]
+---
+
+# 2024-11-05-python-tutorial-part-2.md
+---
+title: "Python Tutorial - Part 2: Data Types"  
+date: 2024-11-05
+series: python-tutorial
+tags: ["python", "tutorial", "programming", "data-types"]
+---
+```
+
+**Generated URLs**:
+- Series page: `/serie-python-tutorial.html`
+- Series RSS: `/serie-python-tutorial.rss`
+- Series JSON: `/serie-python-tutorial.json`
+- Series index: `/series.html`
+
+## Migration from Other Systems
+
+### From Tags/Categories
+If you have tutorial content currently tagged:
+1. Keep existing tags for discoverability
+2. Add `series` field to group related content
+3. Update frontmatter gradually
+
+### From Manual Navigation
+Replace manual "Next/Previous" links - Marmite handles this automatically for series content.
+
+## Technical Details
+
+- Series content is sorted chronologically (oldest first) unlike other content
+- Related content sections are automatically disabled for series posts
+- Series navigation takes precedence over stream navigation
+- All series data is available in templates via the `site_data.series` object
+
+The Series feature makes Marmite perfect for educational content, documentation sites, and any scenario where content order matters. Start organizing your related content today!

--- a/example/marmite.yaml
+++ b/example/marmite.yaml
@@ -35,6 +35,7 @@ menu:
   - ["Archive", "archive.html"]
   - ["Authors", "authors.html"]
   - ["Streams", "streams.html"]
+  - ["Series", "series.html"]
   - ["Github", "https://github.com/rochacbruno/marmite"]
 
 # https://docs.rs/chrono/latest/chrono/format/strftime/index.html
@@ -61,12 +62,18 @@ authors:
 streams:
   alt:
     display_name: "Alternative Stream"
-  # tutorial:
-  #   display_name: "Python Tutorial"
-  # news:
-  #   display_name: "Latest News"
-  # guide:
-  #   display_name: "User Guides"
+  tutorial:
+    display_name: "Tutorials"
+  news:
+    display_name: "Latest News"
+  guide:
+    display_name: "User Guides"
+
+# Series display name mappings
+series:
+  python-tutorial:
+    display_name: "Python Tutorial"
+    description: "A comprehensive Python programming tutorial series"
 
 # Markdown source publishing
 publish_md: true

--- a/example/templates/base_feeds.html
+++ b/example/templates/base_feeds.html
@@ -4,6 +4,10 @@
     {%- set stream_slug = stream | slugify -%}
     <link rel="alternate" type="application/rss+xml" title="{{stream_display_name(stream=stream)}}" href="{{url_for(path=stream_slug ~ '.rss')}}">
     {% endfor %}
+    {%- for series, _ in group(kind="series") -%}
+    {%- set series_slug = series | slugify -%}
+    <link rel="alternate" type="application/rss+xml" title="{{series_display_name(series=series)}}" href="{{url_for(path='series-' ~ series_slug ~ '.rss')}}">
+    {% endfor %}
     {%- for tag, _ in group(kind="tag") -%}
     {%- set tag_slug = tag | slugify -%}
     <link rel="alternate" type="application/rss+xml" title="tag: {{tag}}" href="{{url_for(path='tag-' ~ tag_slug ~ '.rss')}}">
@@ -22,6 +26,10 @@
     {% if stream == "index" or stream == "draft" %}{% continue %}{% endif %}
     {% set stream_slug = stream | slugify %}
     <link rel="alternate" type="application/feed+json" title="JSON {{stream_display_name(stream=stream)}}" href="{{url_for(path=stream_slug ~ '.json')}}">
+    {% endfor %}
+    {%- for series, _ in group(kind="series") -%}
+    {%- set series_slug = series | slugify -%}
+    <link rel="alternate" type="application/feed+json" title="JSON {{series_display_name(series=series)}}" href="{{url_for(path='series-' ~ series_slug ~ '.json')}}">
     {% endfor %}
     {%- for tag, _ in group(kind="tag") -%}
     {%- set tag_slug = tag | slugify -%}

--- a/example/templates/content.html
+++ b/example/templates/content.html
@@ -55,6 +55,11 @@
   {% endif %}
 
   {% include "content_title.html" ignore missing %}
+  {% if content.series %}
+  <div class="content-series">
+    <p><small>Published as part of '<a href="{{ url_for(path='series-' ~ content.series ~ '.html') }}">{{ series_display_name(series=content.series) }}</a>' series.</small></p>
+  </div>
+  {% endif %}
   {% if content.toc %}
   <div class="content-toc">
     <a href="#" id="toc"></a>
@@ -95,7 +100,7 @@
   {% endif %}
 </article>
 
-{% if site.enable_related_content %}
+{% if site.enable_related_content and not content.series %}
 {% if content.back_links %}
 <article>
   Back-links

--- a/example/theme_template/templates/content.html
+++ b/example/theme_template/templates/content.html
@@ -80,6 +80,13 @@
         {% endif %}
     </header>
 
+    {# Series information (if content is part of a series) #}
+    {% if content.series %}
+    <div class="content-series">
+        <p><em>Published as part of '<a href="{{ url_for(path='series-' ~ content.series ~ '.html') }}">{{ series_display_name(series=content.series) }}</a>' series.</em></p>
+    </div>
+    {% endif %}
+
     {# Table of Contents (if enabled and available) #}
     {% if content.toc %}
     <div class="content-toc">
@@ -118,8 +125,8 @@
     {% endif %}
 </article>
 
-{# Related Content Section (if enabled) #}
-{% if site.enable_related_content %}
+{# Related Content Section (if enabled and not part of a series) #}
+{% if site.enable_related_content and not content.series %}
     {# Back-links - other content that links to this content #}
     {% if content.back_links %}
     <section class="related-content">

--- a/src/config.rs
+++ b/src/config.rs
@@ -158,6 +158,12 @@ pub struct Marmite {
     #[serde(default = "default_streams_content_title")]
     pub streams_content_title: String,
 
+    #[serde(default = "default_series_title")]
+    pub series_title: String,
+
+    #[serde(default = "default_series_content_title")]
+    pub series_content_title: String,
+
     #[serde(default)]
     pub default_author: String,
 
@@ -213,6 +219,9 @@ pub struct Marmite {
     pub streams: HashMap<String, StreamConfig>,
 
     #[serde(default)]
+    pub series: HashMap<String, SeriesConfig>,
+
+    #[serde(default)]
     pub toc: bool,
 
     #[serde(default)]
@@ -254,6 +263,9 @@ impl Marmite {
             archives_content_title: default_archives_content_title(),
             authors_title: default_authors_title(),
             streams_title: default_streams_title(),
+            streams_content_title: default_streams_content_title(),
+            series_title: default_series_title(),
+            series_content_title: default_series_content_title(),
             content_path: default_content_path(),
             templates_path: default_templates_path(),
             static_path: default_static_path(),
@@ -389,6 +401,12 @@ pub struct StreamConfig {
     pub display_name: String,
 }
 
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct SeriesConfig {
+    pub display_name: String,
+    pub description: Option<String>,
+}
+
 /// Generates a default configuration file
 /// this function writes to `marmite.yaml` in the input folder
 /// the YAML file will contain the default configuration
@@ -435,6 +453,14 @@ fn default_tags_content_title() -> String {
 
 fn default_streams_content_title() -> String {
     "Posts from '$stream'".to_string()
+}
+
+fn default_series_title() -> String {
+    "Series".to_string()
+}
+
+fn default_series_content_title() -> String {
+    "Posts from '$series' series".to_string()
 }
 
 fn default_pages_title() -> String {

--- a/src/site.rs
+++ b/src/site.rs
@@ -3,7 +3,7 @@ use crate::content::{
     check_for_duplicate_slugs, slugify, Content, ContentBuilder, GroupedContent, Kind,
 };
 use crate::embedded::{generate_static, Templates, EMBEDDED_TERA};
-use crate::tera_functions::{Group, SeriesDisplayName, SourceLink, StreamDisplayName, UrlFor};
+use crate::tera_functions::{DisplayName, Group, SourceLink, UrlFor};
 use crate::{server, tera_filter};
 use chrono::Datelike;
 use core::str;
@@ -575,14 +575,16 @@ fn initialize_tera(input_folder: &Path, site_data: &Data) -> Tera {
     );
     tera.register_function(
         "stream_display_name",
-        StreamDisplayName {
+        DisplayName {
             site_data: site_data.clone(),
+            kind: "stream".to_string(),
         },
     );
     tera.register_function(
         "series_display_name",
-        SeriesDisplayName {
+        DisplayName {
             site_data: site_data.clone(),
+            kind: "series".to_string(),
         },
     );
     tera.register_filter(

--- a/src/site.rs
+++ b/src/site.rs
@@ -3,7 +3,7 @@ use crate::content::{
     check_for_duplicate_slugs, slugify, Content, ContentBuilder, GroupedContent, Kind,
 };
 use crate::embedded::{generate_static, Templates, EMBEDDED_TERA};
-use crate::tera_functions::{Group, SourceLink, StreamDisplayName, UrlFor};
+use crate::tera_functions::{Group, SeriesDisplayName, SourceLink, StreamDisplayName, UrlFor};
 use crate::{server, tera_filter};
 use chrono::Datelike;
 use core::str;
@@ -29,6 +29,7 @@ pub struct Data {
     pub archive: GroupedContent,
     pub author: GroupedContent,
     pub stream: GroupedContent,
+    pub series: GroupedContent,
     pub latest_timestamp: Option<i64>,
     pub config_path: String,
     pub force_render: bool,
@@ -52,6 +53,7 @@ impl Data {
             archive: GroupedContent::new(Kind::Archive),
             author: GroupedContent::new(Kind::Author),
             stream: GroupedContent::new(Kind::Stream),
+            series: GroupedContent::new(Kind::Series),
             latest_timestamp: None,
             config_path: config_path.to_string_lossy().to_string(),
             force_render: false,
@@ -83,6 +85,7 @@ impl Data {
         self.archive.sort_all();
         self.author.sort_all();
         self.stream.sort_all();
+        self.series.sort_all();
     }
 
     /// takes content then classifies the content
@@ -109,6 +112,14 @@ impl Data {
             if let Some(stream) = &content.stream {
                 self.stream
                     .entry(stream.to_string())
+                    .or_default()
+                    .push(content.clone());
+            }
+
+            // series by name
+            if let Some(series) = &content.series {
+                self.series
+                    .entry(series.to_string())
                     .or_default()
                     .push(content.clone());
             }
@@ -388,13 +399,57 @@ fn _collect_back_links(contents: &mut [Content], other_contents: &[Content]) {
 
 #[allow(clippy::cast_possible_wrap)]
 fn set_next_and_previous_links(site_data: &mut std::sync::MutexGuard<'_, Data>) {
-    let mut stream_posts: HashMap<String, Vec<Content>> = HashMap::new();
+    // First, handle series navigation (takes precedence over stream navigation)
+    let mut series_posts: HashMap<String, Vec<Content>> = HashMap::new();
     for post in &site_data.posts {
-        if let Some(stream_name) = &post.stream {
-            stream_posts
-                .entry(stream_name.clone())
+        if let Some(series_name) = &post.series {
+            series_posts
+                .entry(series_name.clone())
                 .or_default()
                 .push(post.clone());
+        }
+    }
+
+    // Sort series posts chronologically (oldest to newest)
+    for posts in series_posts.values_mut() {
+        posts.sort_by(|a, b| a.date.cmp(&b.date));
+    }
+
+    // Set next/previous for posts in series
+    for posts in series_posts.values() {
+        for i in 0..posts.len() {
+            let current_slug = &posts[i].slug;
+
+            let previous = if i > 0 {
+                Some(Box::new(posts[i - 1].clone()))
+            } else {
+                None
+            };
+
+            let next = if i < posts.len() - 1 {
+                Some(Box::new(posts[i + 1].clone()))
+            } else {
+                None
+            };
+
+            if let Some(content) = site_data.posts.iter_mut().find(|c| c.slug == *current_slug) {
+                content.previous = previous;
+                content.next = next;
+            }
+        }
+    }
+
+    // Then handle stream navigation for posts NOT in a series
+    let mut stream_posts: HashMap<String, Vec<Content>> = HashMap::new();
+    for post in &site_data.posts {
+        // Only include posts that are NOT in a series
+        if post.series.is_none() {
+            if let Some(stream_name) = &post.stream {
+                stream_posts
+                    .entry(stream_name.clone())
+                    .or_default()
+                    .push(post.clone());
+            }
         }
     }
 
@@ -524,6 +579,12 @@ fn initialize_tera(input_folder: &Path, site_data: &Data) -> Tera {
             site_data: site_data.clone(),
         },
     );
+    tera.register_function(
+        "series_display_name",
+        SeriesDisplayName {
+            site_data: site_data.clone(),
+        },
+    );
     tera.register_filter(
         "default_date_format",
         tera_filter::DefaultDateFormat {
@@ -605,6 +666,7 @@ fn render_templates(
     collect_global_fragments(content_dir, &mut global_context, tera, &site_data.site);
 
     handle_stream_pages(&site_data, &global_context, tera, output_dir)?;
+    handle_series_pages(&site_data, &global_context, tera, output_dir)?;
     // If site_data.stream.map does not contain the index stream
     // we will render empty index.html from list.html template
     if !site_data.stream.map.contains_key("index") {
@@ -650,7 +712,7 @@ fn handle_group_pages(
     tera: &Tera,
     output_dir: &Path,
 ) -> Result<(), String> {
-    ["tags", "archives", "authors", "streams"]
+    ["tags", "archives", "authors", "streams", "series"]
         .par_iter()
         .map(|step| -> Result<(), String> {
             match *step {
@@ -665,6 +727,9 @@ fn handle_group_pages(
                 }
                 "streams" => {
                     handle_stream_list_page(output_dir, site_data, global_context, tera)?;
+                }
+                "series" => {
+                    handle_series_list_page(output_dir, site_data, global_context, tera)?;
                 }
                 _ => {}
             }
@@ -748,6 +813,58 @@ fn handle_stream_pages(
         .unwrap_or(Ok(()))
 }
 
+/// Handle individual series pages
+/// Generate series-{series}.html pages from list.html template
+/// Series content is sorted chronologically (oldest to newest)
+fn handle_series_pages(
+    site_data: &Data,
+    global_context: &Context,
+    tera: &Tera,
+    output_dir: &Path,
+) -> Result<(), String> {
+    site_data
+        .series
+        .iter()
+        .collect::<Vec<_>>()
+        .par_iter()
+        .map(|(series, series_contents)| -> Result<(), String> {
+            let series_slug = format!("series-{}", slugify(series));
+            let title = site_data
+                .site
+                .series_content_title
+                .replace("$series", series);
+
+            // Series content is already sorted chronologically (oldest to newest) by GroupedContent::sort_all
+            let sorted_series_contents = series_contents.clone();
+
+            handle_list_page(
+                global_context,
+                &title,
+                &sorted_series_contents,
+                site_data,
+                tera,
+                output_dir,
+                &series_slug,
+            )?;
+
+            // Generate RSS feed for series
+            crate::feed::generate_rss(series_contents, output_dir, &series_slug, &site_data.site)?;
+
+            if site_data.site.json_feed {
+                crate::feed::generate_json(
+                    series_contents,
+                    output_dir,
+                    &series_slug,
+                    &site_data.site,
+                )?;
+            }
+
+            Ok(())
+        })
+        .reduce_with(|r1, r2| if r1.is_err() { r1 } else { r2 })
+        .unwrap_or(Ok(()))
+}
+
 fn handle_default_empty_site(
     global_context: &Context,
     tera: &Tera,
@@ -787,6 +904,26 @@ fn handle_stream_list_page(
         "streams.html",
         tera,
         &stream_list_context,
+        output_dir,
+    )?;
+    Ok(())
+}
+
+fn handle_series_list_page(
+    output_dir: &Path,
+    site_data: &Data,
+    global_context: &Context,
+    tera: &Tera,
+) -> Result<(), String> {
+    let mut series_list_context = global_context.clone();
+    series_list_context.insert("title", &site_data.site.series_title);
+    series_list_context.insert("current_page", "series.html");
+    series_list_context.insert("kind", "series");
+    render_html(
+        "group.html",
+        "series.html",
+        tera,
+        &series_list_context,
         output_dir,
     )?;
     Ok(())

--- a/src/tera_functions.rs
+++ b/src/tera_functions.rs
@@ -87,6 +87,7 @@ impl Function for Group {
             "archive" => &self.site_data.archive,
             "author" => &self.site_data.author,
             "stream" => &self.site_data.stream,
+            "series" => &self.site_data.series,
             _ => return Err(tera::Error::msg("Invalid `kind` argument")),
         };
 
@@ -172,6 +173,30 @@ impl Function for StreamDisplayName {
         } else {
             // Return the stream name itself if no display name is configured
             to_value(stream_name).map_err(tera::Error::from)
+        }
+    }
+}
+
+/// Tera template function that returns the display name for a series
+/// It takes a `series` argument and returns the configured display name
+/// If no display name is configured, returns the series name itself
+pub struct SeriesDisplayName {
+    pub site_data: Data,
+}
+
+impl Function for SeriesDisplayName {
+    fn call(&self, args: &HashMap<String, Value>) -> TeraResult<Value> {
+        let series_name = args
+            .get("series")
+            .and_then(Value::as_str)
+            .ok_or_else(|| tera::Error::msg("Missing `series` argument"))?;
+
+        // Check if there's a configured display name for this series
+        if let Some(series_config) = self.site_data.site.series.get(series_name) {
+            to_value(&series_config.display_name).map_err(tera::Error::from)
+        } else {
+            // Return the series name itself if no display name is configured
+            to_value(series_name).map_err(tera::Error::from)
         }
     }
 }

--- a/src/tera_functions.rs
+++ b/src/tera_functions.rs
@@ -153,50 +153,43 @@ impl Function for SourceLink {
     }
 }
 
-/// Tera template function that returns the display name for a stream
-/// It takes a `stream` argument and returns the configured display name
-/// If no display name is configured, returns the stream name itself
-pub struct StreamDisplayName {
+/// Tera template function that returns the display name for a stream or series
+/// It takes a `stream` or `series` argument and returns the configured display name
+/// If no display name is configured, returns the stream/series name itself
+pub struct DisplayName {
     pub site_data: Data,
+    pub kind: String,
 }
 
-impl Function for StreamDisplayName {
+impl Function for DisplayName {
     fn call(&self, args: &HashMap<String, Value>) -> TeraResult<Value> {
-        let stream_name = args
-            .get("stream")
+        let name = args
+            .get(&self.kind)
             .and_then(Value::as_str)
-            .ok_or_else(|| tera::Error::msg("Missing `stream` argument"))?;
+            .ok_or_else(|| tera::Error::msg(format!("Missing `{}` argument", self.kind)))?;
 
-        // Check if there's a configured display name for this stream
-        if let Some(stream_config) = self.site_data.site.streams.get(stream_name) {
-            to_value(&stream_config.display_name).map_err(tera::Error::from)
+        // Check if there's a configured display name based on the kind
+        let display_name = match self.kind.as_str() {
+            "stream" => self
+                .site_data
+                .site
+                .streams
+                .get(name)
+                .map(|config| &config.display_name),
+            "series" => self
+                .site_data
+                .site
+                .series
+                .get(name)
+                .map(|config| &config.display_name),
+            _ => None,
+        };
+
+        if let Some(display_name) = display_name {
+            to_value(display_name).map_err(tera::Error::from)
         } else {
-            // Return the stream name itself if no display name is configured
-            to_value(stream_name).map_err(tera::Error::from)
-        }
-    }
-}
-
-/// Tera template function that returns the display name for a series
-/// It takes a `series` argument and returns the configured display name
-/// If no display name is configured, returns the series name itself
-pub struct SeriesDisplayName {
-    pub site_data: Data,
-}
-
-impl Function for SeriesDisplayName {
-    fn call(&self, args: &HashMap<String, Value>) -> TeraResult<Value> {
-        let series_name = args
-            .get("series")
-            .and_then(Value::as_str)
-            .ok_or_else(|| tera::Error::msg("Missing `series` argument"))?;
-
-        // Check if there's a configured display name for this series
-        if let Some(series_config) = self.site_data.site.series.get(series_name) {
-            to_value(&series_config.display_name).map_err(tera::Error::from)
-        } else {
-            // Return the series name itself if no display name is configured
-            to_value(series_name).map_err(tera::Error::from)
+            // Return the name itself if no display name is configured
+            to_value(name).map_err(tera::Error::from)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Implements Series feature allowing content to be grouped into ordered collections
- Adds support for series frontmatter field and configuration
- Closes #102

## Changes
- Added series support to content structure and parsing
- Created dedicated series pages with chronological ordering
- Implemented series index page showing all available series
- Added series navigation with precedence over stream navigation
- Generated RSS and JSON feeds for each series
- Updated templates to display series links and handle related content
- Fixed series feed URL generation (from `serie-` to `series-` prefix)

## Testing
- Added comprehensive example content with Python tutorial series
- Created documentation post explaining the feature
- All tests pass (`cargo test`)
- Code quality checks pass (`mask check`, `mask pedantic`)

## Examples
The implementation includes a complete Python tutorial series example demonstrating:
- Series frontmatter configuration
- Chronological ordering (oldest to newest)
- Navigation between series parts
- Series index page functionality
- RSS/JSON feed generation