### PR TITLE
fix: use media_path from config instead of hardcoded value

### DIFF
--- a/src/content.rs
+++ b/src/content.rs
@@ -176,8 +176,8 @@ impl Content {
             }
         }
 
-        let card_image = get_card_image(&frontmatter, &html, path, &slug);
-        let banner_image = get_banner_image(&frontmatter, path, &slug);
+        let card_image = get_card_image(&frontmatter, &html, path, &slug, &site.media_path);
+        let banner_image = get_banner_image(&frontmatter, path, &slug, &site.media_path);
         let authors = get_authors(&frontmatter, Some(site.default_author.clone()));
         let pinned = frontmatter
             .get("pinned")
@@ -749,18 +749,20 @@ pub fn get_card_image(
     html: &str,
     path: &Path,
     slug: &str,
+    media_path: &str,
 ) -> Option<String> {
     if let Some(card_image) = frontmatter.get("card_image") {
         return Some(card_image.to_string());
     }
 
     // Try to find image matching the slug
-    if let Some(value) = find_matching_file(slug, path, "card", &["png", "jpg", "jpeg"]) {
+    if let Some(value) = find_matching_file(slug, path, "card", &["png", "jpg", "jpeg"], media_path)
+    {
         return Some(value);
     }
 
     // try banner_image
-    if let Some(banner_image) = get_banner_image(frontmatter, path, slug) {
+    if let Some(banner_image) = get_banner_image(frontmatter, path, slug, media_path) {
         return Some(banner_image);
     }
 
@@ -777,8 +779,13 @@ pub fn get_card_image(
 /// if the file exists, return the path to the file
 /// if not found in media folder, try to find in the same directory
 /// if the file does not exist, return None
-fn find_matching_file(slug: &str, path: &Path, kind: &str, exts: &[&str]) -> Option<String> {
-    let media_folder_name = "media";
+fn find_matching_file(
+    slug: &str,
+    path: &Path,
+    kind: &str,
+    exts: &[&str],
+    media_folder_name: &str,
+) -> Option<String> {
     let parent_path = path.parent().unwrap_or(path);
     let media_path = parent_path.join(media_folder_name);
     for ext in exts {
@@ -796,7 +803,12 @@ fn find_matching_file(slug: &str, path: &Path, kind: &str, exts: &[&str]) -> Opt
     None
 }
 
-fn get_banner_image(frontmatter: &Frontmatter, path: &Path, slug: &str) -> Option<String> {
+fn get_banner_image(
+    frontmatter: &Frontmatter,
+    path: &Path,
+    slug: &str,
+    media_path: &str,
+) -> Option<String> {
     if let Some(banner_image) = frontmatter.get("banner_image") {
         return Some(
             banner_image
@@ -808,7 +820,9 @@ fn get_banner_image(frontmatter: &Frontmatter, path: &Path, slug: &str) -> Optio
     }
 
     // Try to find image matching the slug
-    if let Some(value) = find_matching_file(slug, path, "banner", &["png", "jpg", "jpeg"]) {
+    if let Some(value) =
+        find_matching_file(slug, path, "banner", &["png", "jpg", "jpeg"], media_path)
+    {
         return Some(value);
     }
 

--- a/src/tests/content.rs
+++ b/src/tests/content.rs
@@ -506,7 +506,7 @@ fn test_get_card_image_from_frontmatter() {
     let expected = Some("\"media/image.jpg\"".to_string());
     // assert_eq!(get_card_image(&frontmatter, html, ), expected);
     assert_eq!(
-        get_card_image(&frontmatter, html, Path::new("test"), "test"),
+        get_card_image(&frontmatter, html, Path::new("test"), "test", "media"),
         expected
     );
 }
@@ -517,7 +517,7 @@ fn test_get_card_image_from_html() {
     let html = r#"<p>Some content</p><img src="media/image.jpg" />"#;
     let expected = Some("media/image.jpg".to_string());
     assert_eq!(
-        get_card_image(&frontmatter, html, Path::new("test"), "test"),
+        get_card_image(&frontmatter, html, Path::new("test"), "test", "media"),
         expected
     );
 }
@@ -528,7 +528,7 @@ fn test_get_card_image_no_image() {
     let html = "<p>Some content</p>";
     let expected: Option<String> = None;
     assert_eq!(
-        get_card_image(&frontmatter, html, Path::new("test"), "test"),
+        get_card_image(&frontmatter, html, Path::new("test"), "test", "media"),
         expected
     );
 }
@@ -539,7 +539,7 @@ fn test_get_card_image_with_multiple_images() {
     let html = r#"<p>Some content</p><img src="image1.jpg" /><img src="image2.jpg" />"#;
     let expected = Some("image1.jpg".to_string());
     assert_eq!(
-        get_card_image(&frontmatter, html, Path::new("test"), "test"),
+        get_card_image(&frontmatter, html, Path::new("test"), "test", "media"),
         expected
     );
 }
@@ -550,7 +550,7 @@ fn test_get_card_image_with_invalid_html() {
     let html = r#"<p>Some content</p><img src="image.jpg"#;
     let expected: Option<String> = None;
     assert_eq!(
-        get_card_image(&frontmatter, html, Path::new("test"), "test"),
+        get_card_image(&frontmatter, html, Path::new("test"), "test", "media"),
         expected
     );
 }

--- a/src/tests/image_provider.rs
+++ b/src/tests/image_provider.rs
@@ -39,7 +39,7 @@ fn test_download_banner_image_with_picsum() {
     thread::spawn(move || {
         // Check if we can reach picsum.photos
         let test_url = "https://picsum.photos/health";
-        if let Ok(_) = ureq::get(test_url).call() {
+        if ureq::get(test_url).call().is_ok() {
             // Server is reachable, proceed with test
             let config = create_test_config();
             let frontmatter = Frontmatter::new();


### PR DESCRIPTION
## Summary
This PR fixes a bug where the media folder name was hardcoded to `"media"` instead of using the configurable `media_path` value from the site configuration.

## Problem
The `find_matching_file` function in `content.rs` was using a hardcoded `"media"` string instead of respecting the user's configured `media_path` setting in `marmite.yaml`.

## Solution
- Pass `media_path` from site configuration through the function chain
- Update `get_card_image` and `get_banner_image` functions to accept the `media_path` parameter
- Fix recursive call to `get_banner_image` within `get_card_image`
- Update all related tests to pass the media_path parameter

## Changes
- Modified `src/content.rs`:
  - Updated function signatures to accept `media_path` parameter
  - Replaced hardcoded `"media"` with configurable value
- Modified `src/tests/content.rs`:
  - Updated test calls to include media_path parameter
- Modified `src/tests/image_provider.rs`:
  - Fixed clippy warning (unrelated minor fix)

## Test plan
- [x] All existing tests pass
- [x] `cargo test` - 220 tests pass
- [x] `mask fmt` - Code formatted
- [x] `mask check` - No clippy warnings
- [x] `mask pedantic` - No pedantic warnings

## Breaking changes
None - This is an internal fix that maintains backward compatibility.