### PR TITLE
Add preferred theme scheme option

### DIFF
--- a/example/marmite.yaml
+++ b/example/marmite.yaml
@@ -85,6 +85,9 @@ publish_urls_json: true
 # extra data for template customization
 extra:
   colorscheme_toggle: true
+  #colorscheme: dracula
+  colormode: dark
+  colormodetoggle: false
   # colorscheme: minimal_wb
   static_folders:
     - extrastatic

--- a/example/static/marmite.js
+++ b/example/static/marmite.js
@@ -15,7 +15,7 @@ const themeSwitcher = {
     
     // Get color scheme from local storage
     get schemeFromLocalStorage() {
-        return window.localStorage?.getItem(this.localStorageKey) ?? this._scheme;
+        return window.localStorage?.getItem(this.localStorageKey);
     },
     
     // Preferred color scheme

--- a/example/templates/base.html
+++ b/example/templates/base.html
@@ -79,7 +79,9 @@
                         {% endif %}
                     </li>
                     {% endfor %}
-                    <li><span class="theme-toggle secondary" title="dark mode">&#9789;</span></li>
+                    {% if site.extra.colormodetoggle %}
+                        <li><span class="theme-toggle secondary" title="dark mode">&#9789;</span></li>
+                    {% endif %}
                     {% if site.enable_search %}
                     <li><a href="#" id="search-toggle" class="secondary" title="Search (Ctrl + Shift + F)"> <span class="search-txt">Search</span><span class="search-magnifier"></span></a></li>
                     {% endif %}
@@ -122,10 +124,19 @@
     {% if site.enable_search %}
     <script type="module" src="{{url_for(path='static/search.js')}}"></script>
     {% endif %}
-    {% if site.extra.colorscheme_toggle %}
+    {% if site.extra.colorscheme_toggle %}    
     <script type="application/javascript" >
         colorschemeSwitcher();
     </script>
+    {% endif %}
+    {% if site.extra.colormode %}
+        <script type="application/javascript">
+            // If there is already a scheme saved in localstorage, load that, else load config
+            if (themeSwitcher.scheme == "auto") {
+                themeSwitcher.scheme = "{{ site.extra.colormode }}";
+                themeSwitcher.updateIcon();
+            }
+        </script>
     {% endif %}
     {% endblock -%}
     {% if htmltail is defined %}


### PR DESCRIPTION
Add extra/colormode to the marmite.yaml settings that can be "auto", "dark" or "light" to set a preferred theme style when the page is loaded.

If a user toggles the scheme on the page, their setting is saved to their local storage and on next page load the config setting is ignored. The config setting is only ignored if the local storage value is not "auto"

A new setting `colormodetogggle` which accepts a boolean is added that allows the user to enable/disable the colormode toggle in the header of the page, fixing the page to the color set (either by system or by config)

Fixes #200 