### PR TITLE
Pedantic fixes

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -48,7 +48,7 @@ const LIVE_RELOAD_SCRIPT: &str = r#"(() => {
     connect();
 })();"#;
 
-pub fn start(bind_address: &str, output_folder: &Arc<PathBuf>, live_reload: Option<LiveReload>) {
+pub fn start(bind_address: &str, output_folder: &Arc<PathBuf>, live_reload: Option<&LiveReload>) {
     let server = match Server::http(bind_address) {
         Ok(server) => server,
         Err(e) => {
@@ -64,7 +64,7 @@ pub fn start(bind_address: &str, output_folder: &Arc<PathBuf>, live_reload: Opti
     info!("Server started at http://{bind_address}/ - Type ^C to stop.",);
 
     for request in server.incoming_requests() {
-        if let Some(live_reload_handler) = live_reload.clone() {
+        if let Some(live_reload_handler) = live_reload {
             if is_live_reload_ws_request(&request) {
                 live_reload_handler.accept(request);
                 continue;
@@ -256,7 +256,7 @@ impl LiveReload {
             "timestamp": Utc::now().timestamp_millis(),
         })
         .to_string();
-        self.broadcast(payload);
+        self.broadcast(&payload);
     }
 
     fn accept_internal(&self, request: Request) -> Result<(), String> {
@@ -341,9 +341,9 @@ impl LiveReload {
         }
     }
 
-    fn broadcast(&self, message: String) {
+    fn broadcast(&self, message: &str) {
         if let Ok(mut clients) = self.clients.lock() {
-            clients.retain(|client| client.sender.send(message.clone()).is_ok());
+            clients.retain(|client| client.sender.send(message.to_string()).is_ok());
         }
     }
 }

--- a/src/site.rs
+++ b/src/site.rs
@@ -632,7 +632,7 @@ pub fn generate(
             server::start(
                 bind_address,
                 &Arc::clone(output_folder),
-                live_reload.clone(),
+                live_reload.as_ref(),
             );
         } else {
             loop {


### PR DESCRIPTION
1. src/server.rs:51 - Changed live_reload: Option<LiveReload> to Option<&LiveReload> to
  avoid unnecessary cloning
    - Updated the parameter signature
    - Removed unnecessary .clone() call on line 67
  2. src/server.rs:344 - Changed message: String to message: &str in the broadcast method
    - Updated the method to convert &str to String when sending messages
    - Updated the call site on line 259 to pass &payload instead of payload
  3. src/site.rs:635 - Updated the call site to pass live_reload.as_ref() instead of
  live_reload.clone()