### PR TITLE
fix: Keep post title capitalization in listings

### DIFF
--- a/example/templates/list.html
+++ b/example/templates/list.html
@@ -71,7 +71,7 @@
         {% if content.date %}<time class="dt-published" datetime="{{ content.date | date(format='%+') }}" style="display: none;">{{ content.date | default_date_format }}</time>{% endif %}
         
         <div class="content-title-wrapper">
-            <h2 class="content-title"><a href="{{url_for(path=content.slug ~ '.html')}}">{{ content.title | capitalize }}</a></h2>
+            <h2 class="content-title"><a href="{{url_for(path=content.slug ~ '.html')}}">{{ content.title }}</a></h2>
             {%if content.pinned %}<span class="content-pin">&star;</span>{%endif%} 
         </div>
         <p class="content-excerpt p-summary">

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,7 @@
 use crate::config::ParserOptions;
 use crate::content::slugify;
 use crate::re;
-use comrak::{markdown_to_html, BrokenLinkReference, ComrakOptions, ResolvedReference};
+use comrak::{markdown_to_html, options::BrokenLinkReference, Options, ResolvedReference};
 use frontmatter_gen::{detect_format, extract_raw_frontmatter, parse, Frontmatter};
 use log::warn;
 use regex::Regex;
@@ -107,12 +107,12 @@ pub fn get_html(markdown: &str) -> String {
 
 /// Convert markdown to html using comrak with configurable options
 pub fn get_html_with_options(markdown: &str, parser_options: &ParserOptions) -> String {
-    let mut options = ComrakOptions::default();
+    let mut options = Options::default();
 
     // Apply configurable render options
     options.render.figure_with_caption = parser_options.render.figure_with_caption;
     options.render.ignore_empty_links = parser_options.render.ignore_empty_links;
-    options.render.unsafe_ = parser_options.render.unsafe_;
+    options.render.r#unsafe = parser_options.render.unsafe_;
 
     // Apply configurable parse options
     options.parse.broken_link_callback = Some(Arc::new(warn_broken_link)); // Not configurable


### PR DESCRIPTION
Fixes #357.

Also, the `main` branch doesn't currently build. I presume this was due to upgrading the `comrak` dependency (dependabot). They made some breaking API changes, which I have also addressed in the process of creating this PR.