### PR TITLE
docs: Update marmite installation command in example

### DIFF
--- a/example/content/hosting.md
+++ b/example/content/hosting.md
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install marmite 🫙
-        run: cargo install marmite
+        run: curl -sS https://marmite.blog/install.sh | sh
 
       - name: Build site 🏗️
         run: marmite . site --debug


### PR DESCRIPTION
Change installation method for marmite from cargo install to a script in example documentation. 

Installing via script is way faster for CI than installing via Cargo