### PR TITLE
docs: change installation step to use install script in example

### DIFF
--- a/example/content/hosting.md
+++ b/example/content/hosting.md
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install marmite 🫙
-        run: cargo install marmite
+        run: curl -sS https://marmite.blog/install.sh | sh
 
       - name: Build site 🏗️
         run: marmite . site --debug


### PR DESCRIPTION
Updated example for installation method for marmite to use the script rather than cargo installation bexause is faster for CI build.