### PR TITLE
Fix Obsidian links pointing to different slug.

### DIFF
--- a/example/content/2025-11-24-wikilinks-demo.md
+++ b/example/content/2025-11-24-wikilinks-demo.md
@@ -1,0 +1,88 @@
+---
+title: "Wikilinks Demo & How To Guide"
+description: "A demonstration of Obsidian-style wikilinks in Marmite with proper slug resolution"
+tags: ["features", "documentation", "wikilinks"]
+---
+
+# Wikilinks Demo & How To Guide
+
+This post demonstrates the **Obsidian-style wikilink** functionality in Marmite. Wikilinks allow you to create internal links using double square brackets, like in Obsidian, Notion, and other note-taking apps.
+
+## What are Wikilinks?
+
+Wikilinks are internal links written using double square brackets: `[[Title of Target Content]]`. They're especially useful for:
+
+- Creating interconnected note systems
+- Linking between related posts and pages
+- Building knowledge bases and wikis
+- Quick internal linking without worrying about slugs
+
+## How Wikilinks Work in Marmite
+
+When you write a wikilink like `[[Title of Target Content]]`, Marmite:
+
+1. **Converts** it to HTML with a `data-wikilink="true"` attribute
+2. **Searches** for content with a matching title (case-insensitive)
+3. **Replaces** the auto-generated filename-based href with the proper slug
+4. **Falls back** to the original href if no matching content is found
+
+## Example Wikilinks
+
+Here are some example wikilinks to other content in this blog:
+
+- [[About]] - Links to the about page
+- [[Getting Started]] - Links to the getting started guide  
+- [[Python Tutorial - Part 1: Getting Started]] - Links to the first Python tutorial
+- [[Title is A]] - Links to a content with a different slug
+- [[Markdown Format]] - Links to the markdown documentation
+- [[Configuration Reference]] - Links to configuration docs
+
+You can also reference posts with special characters:
+- [[TWSBI Eco Indigo Blue & de Atramentis Document Brown]] - Would link to a post with that exact title
+
+## Wikilink Configuration
+
+Wikilinks are enabled by default in Marmite. You can configure them in your `marmite.yaml`:
+
+```yaml
+markdown_parser:
+  extension:
+    wikilinks_title_before_pipe: true   # [[Title|Display Text]]
+    wikilinks_title_after_pipe: false   # [[Display Text|Title]]
+```
+
+## Benefits Over Regular Markdown Links
+
+**Wikilinks** (`[[Title]]`):
+- ✅ No need to remember slugs or filenames
+- ✅ Automatic slug resolution
+- ✅ Works with titles containing special characters
+- ✅ Case-insensitive matching
+- ✅ Obsidian/Notion compatibility
+
+**Regular links** (`[Text](slug.html)`):
+- ❌ Must know exact slug or filename
+- ❌ Manual slug maintenance if titles change
+- ❌ Case-sensitive
+
+## Technical Implementation
+
+The wikilink processing happens during HTML generation:
+
+1. **Markdown → HTML**: `comrak` converts `[[Title]]` to `<a href="auto-generated.html" data-wikilink="true">Title</a>`
+2. **Post-processing**: Marmite finds `data-wikilink="true"` links and attempts title matching
+3. **Slug resolution**: If a matching title is found, the href is replaced with the correct slug
+4. **Fallback**: If no match is found, the original auto-generated href is preserved
+
+This approach provides a pragmatic solution that works with the current Marmite architecture while maintaining compatibility with existing functionality.
+
+## Try It Yourself
+
+To test wikilinks in your own Marmite site:
+
+1. Ensure wikilinks are enabled in your config (they are by default)
+2. Create content with exact titles you want to reference
+3. Use `[[Exact Title]]` syntax in your markdown
+4. Build your site and verify the links work correctly
+
+Happy linking! 🔗

--- a/example/content/slug_differs.md
+++ b/example/content/slug_differs.md
@@ -1,0 +1,15 @@
+---
+title: Title is A
+slug: Slug is B
+---
+
+This is a page to test the wikilinks feature [[Wikilinks Demo & How To Guide]]
+
+
+```markdown
+On this page the `Title is A` but `Slug is B` and marmite can 
+still postprocess the wikilinks to parse [[Title is A]] 
+correctly or even [[Slug is B]]
+```
+
+On this page the `Title is A` but `Slug is B` and marmite can still postprocess the wikilinks to parse [[Title is A]] correctly or even [[Slug is B]]

--- a/src/re.rs
+++ b/src/re.rs
@@ -32,6 +32,12 @@ pub const CAPTURE_LINK_AND_TEXT_FROM_A_TAG: &str =
 /// Used for extracting image URLs from HTML content
 pub const CAPTURE_SRC_FROM_IMG_HTMLTAG: &str = r#"<img[^>]*src=['\"]([^'\"]+)['\"]"#;
 
+/// Matches wikilink anchor tags with data-wikilink attribute
+/// Captures: 1) href attribute value, 2) link text content
+/// Used for fixing Obsidian wikilinks to use proper slugs instead of filename-based hrefs
+pub const CAPTURE_WIKILINK_HREF_AND_TITLE: &str =
+    r#"<a[^>]*href=['\"]([^'\"]+)['\"][^>]*data-wikilink=['\"]true['\"][^>]*>(.*?)</a>"#;
+
 // === Shortcode Patterns ===
 
 /// Default pattern for HTML comment-style shortcodes

--- a/tests/wikilinks_integration.rs
+++ b/tests/wikilinks_integration.rs
@@ -1,0 +1,90 @@
+use std::fs;
+use tempfile::TempDir;
+
+#[test]
+fn test_wikilinks_integration() {
+    let temp_dir = TempDir::new().unwrap();
+    let temp_path = temp_dir.path();
+
+    // Create content directory structure
+    let content_dir = temp_path.join("content");
+    fs::create_dir_all(&content_dir).unwrap();
+
+    // Create a post that will be referenced via wikilink
+    let target_post = content_dir.join("target-post.md");
+    fs::write(
+        &target_post,
+        r#"---
+title: "My Amazing Post"
+slug: amazing-post-custom-slug
+---
+
+This is the target post.
+"#,
+    )
+    .unwrap();
+
+    // Create a post with wikilinks
+    let source_post = content_dir.join("source-post.md");
+    fs::write(
+        &source_post,
+        r#"---
+title: "Source Post"
+---
+
+This post links to [[My Amazing Post]] using wikilinks.
+Also links to [[Nonexistent Post]] which should remain unchanged.
+"#,
+    )
+    .unwrap();
+
+    // Create config file
+    let config_file = temp_path.join("marmite.yaml");
+    fs::write(
+        &config_file,
+        r#"
+name: Test Blog
+url: https://test.blog
+"#,
+    )
+    .unwrap();
+
+    // Generate the site
+    let output_dir = temp_path.join("site");
+    let status = std::process::Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--",
+            temp_path.to_str().unwrap(),
+            output_dir.to_str().unwrap(),
+            "--force",
+        ])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .status()
+        .expect("Failed to run marmite");
+
+    assert!(status.success(), "Marmite generation failed");
+
+    // Check the generated source post HTML
+    let source_html_file = output_dir.join("source-post.html");
+    assert!(source_html_file.exists(), "Source post HTML not generated");
+
+    let html_content = fs::read_to_string(source_html_file).unwrap();
+
+    // Check that the wikilink was properly resolved to use the custom slug
+    assert!(
+        html_content.contains(
+            r#"<a href="amazing-post-custom-slug.html" data-wikilink="true">My Amazing Post</a>"#
+        ),
+        "Wikilink was not properly resolved to custom slug. HTML content: {}",
+        html_content
+    );
+
+    // Check that the nonexistent wikilink remained unchanged
+    assert!(
+        html_content.contains(r#"data-wikilink="true">Nonexistent Post</a>"#),
+        "Nonexistent wikilink should retain data-wikilink attribute. HTML content: {}",
+        html_content
+    );
+}


### PR DESCRIPTION
Fix #362

Now on html postprocessing the wikilinks will be corrected via title matching.