### PR TITLE
fix: merge user static files on top of embedded defaults

### DIFF
--- a/example/content/2024-10-24-21-05-12-getting-started.md
+++ b/example/content/2024-10-24-21-05-12-getting-started.md
@@ -763,6 +763,19 @@ to any static file you want, create a folder named `static` and put any
 > marmite generates **flat html** website, all static file url
 > will be relative like `./static/style.css` `./static/fonts/font.woof` etc.
 
+When no theme is set, you don't need to provide a complete `static` folder.
+Marmite will first write the embedded static files (CSS, JS, fonts, colorschemes)
+to the output, then copy your `static/` folder on top. Any files you provide
+override the embedded defaults, while embedded files you didn't replace remain
+available.
+
+> [!WARNING]
+> If you override a core embedded file (such as `marmite.css`, `search.js`,
+> `pico.min.css`, `marmite.js`, fonts, or colorschemes), Marmite will warn you
+> when the embedded version has changed — typically after a Marmite upgrade.
+> To resolve the drift, review the changes and either update your copy or delete
+> it from your `static/` folder to use the new embedded version.
+
 If you don't want to create all static files by hand, but want to reuse the 
 embedded theme, you can run.
 
@@ -814,11 +827,16 @@ myblog/
 myblog/
    |_ content/                     # Markdown content
    |_ templates/                   # Global templates
-   |_ static/                      # Global static files
+   |_ static/                      # Custom static files (merged with embedded)
    |_ marmite.yaml                 # Config (no theme specified)
    |_ custom.css                   # Optional css
    |_ custom.js                    # Optional JS
 ```
+
+> [!NOTE]
+> In the legacy structure, your `static/` folder is merged on top of the
+> embedded static files. You only need to include files you want to add or
+> override — the embedded CSS, JS, fonts, and colorschemes are always available.
 
 ## Looking for help
 

--- a/example/content/2025-07-10-20-31-29-configuration-reference.md
+++ b/example/content/2025-07-10-20-31-29-configuration-reference.md
@@ -169,8 +169,13 @@ theme: "mytheme"                  # Theme name (default: none)
 
 When a theme is specified, Marmite will:
 - Load templates from `{theme}/templates/` instead of `templates/`
-- Copy static files from `{theme}/static/` instead of `static/`
+- Copy static files from `{theme}/static/` instead of `static/` (the theme provides a complete set; embedded files are not used)
 - Fall back to embedded templates if theme files are missing
+
+When no theme is specified, Marmite writes the embedded static files first, then
+merges your `static/` folder on top — your files override matching embedded files
+while the rest remain available. Marmite will warn if your overrides of core files
+(like `marmite.css`, `search.js`, `pico.min.css`) differ from the embedded version.
 
 **CLI Override**: Use `--theme mytheme` to override the configuration theme for a single build.
 

--- a/example/content/2025-07-11-20-31-29-themes-feature.md
+++ b/example/content/2025-07-11-20-31-29-themes-feature.md
@@ -115,17 +115,24 @@ This CLI option is useful for:
 
 When a theme is set (either via config or CLI), Marmite will:
 - Look for templates in `mytheme/templates/` instead of `templates/`
-- Copy static files from `mytheme/static/` instead of `static/`
+- Copy static files from `mytheme/static/` instead of `static/` (the theme provides a complete set of static files; embedded files are not used)
 - Fall back to embedded templates if theme files are missing
 
 > **Note**: The CLI `--theme` option takes precedence over the configuration file setting.
 
 ## Default Behavior
 
-If no theme is specified (or `theme: null`), Marmite works as before:
+If no theme is specified (or `theme: null`), Marmite uses the embedded static files
+as a base and merges your `static/` folder on top:
 - Templates are loaded from `templates/`
-- Static files are copied from `static/`
-- This maintains backward compatibility with existing sites
+- Embedded static files (CSS, JS, fonts, colorschemes) are written first
+- Your `static/` files are then copied on top, overriding any matching embedded files
+- Files you didn't override remain available from the embedded set
+
+If you override a core embedded file (like `marmite.css`, `search.js`, `pico.min.css`,
+`marmite.js`, fonts, or colorschemes), Marmite will warn you when the embedded version
+differs from yours. This typically happens after upgrading Marmite. To resolve it,
+review the changes and either update your copy or remove it to use the embedded version.
 
 ## Embedded Theme Template
 

--- a/example/content/2026-04-22-23-00-01-marmite-0-3-1-release-notes.md
+++ b/example/content/2026-04-22-23-00-01-marmite-0-3-1-release-notes.md
@@ -1,0 +1,73 @@
+---
+title: Marmite 0.3.1 Release Notes
+slug: marmite-0-3-1-release-notes
+description: "Marmite 0.3.1 fixes static file handling so user files are merged on top of embedded defaults, with drift warnings for core files."
+tags: [release-notes, marmite, features, announcement]
+author: rochacbruno
+pinned: true
+draft: true
+---
+
+We're excited to announce Marmite 0.3.1! This release fixes how static files are handled when users provide their own `static/` folder, ensuring embedded and user files are properly merged instead of requiring users to provide a complete replacement.
+
+## 🐛 Bug Fixes
+
+### Static Files Now Merged with Embedded Defaults
+
+Previously, if your project had a `static/` folder (even with just one file like `foo.png`), Marmite would copy only your folder to the output and skip all embedded static files. This meant the site would be missing core assets like `marmite.css`, `pico.min.css`, `search.js`, fonts, and colorschemes — breaking the default theme.
+
+Now, when no theme is set, Marmite always writes the embedded static files first, then copies your `static/` folder on top. Your files override matching embedded files while the rest remain available.
+
+**Before (broken):**
+```
+blog/static/foo.png  →  output/static/foo.png  (only your file, site breaks)
+```
+
+**After (fixed):**
+```
+blog/static/foo.png  →  output/static/foo.png       (your file)
+                         output/static/marmite.css   (from embedded)
+                         output/static/pico.min.css  (from embedded)
+                         output/static/search.js     (from embedded)
+                         output/static/...           (all other embedded files)
+```
+
+### Drift Warnings for Core Static Files
+
+When you override a core embedded file (like `marmite.css`, `marmite.js`, `search.js`, `pico.min.css`, fonts, or colorschemes), Marmite now warns you if the embedded version differs from yours. This typically happens after upgrading Marmite, when the embedded file contains fixes or improvements.
+
+```
+WARN: Static file 'search.js' differs from the embedded version.
+      The embedded version may contain updates or fixes.
+      To use the embedded version, remove 'blog/static/search.js' from your static folder.
+```
+
+Your customized version is always preserved — the warning is informational so you can decide whether to adopt the updated embedded version.
+
+## 🎨 Theme Behavior
+
+When a theme is set via `theme:` in configuration or `--theme` on the CLI, the behavior is unchanged: the theme's `static/` folder provides a complete set of static files and the embedded files are not used.
+
+## Upgrading
+
+To upgrade to Marmite 0.3.1:
+
+```bash
+# If installed via cargo
+cargo install marmite --force
+
+# If installed via pip
+pip install --upgrade marmite
+
+# Or use the install script
+curl -sSL https://marmite.blog/install.sh | bash
+```
+
+### Migration Notes
+
+1. **If you relied on `static/` replacing all embedded files** — This is no longer the case. Your `static/` folder is now merged on top of embedded files. If you intentionally replaced a core file, it will still be used, but you'll see a drift warning if it differs from the embedded version.
+2. **No action needed for most users** — If you had a `static/` folder with only custom files (images, extra CSS, etc.), your site will now work correctly without needing to copy all embedded files manually.
+
+---
+
+For the complete changelog, see the [GitHub releases page](https://github.com/rochacbruno/marmite/releases/tag/0.3.1).

--- a/example/content/customizing-templates.md
+++ b/example/content/customizing-templates.md
@@ -353,8 +353,21 @@ With the above HTML your index page will look like:
 Just create a `static` folder side by side with your `templates` folder and add
 all `css`, `js`, `fonts` etc on this folder.
 
-Marmite will copy this folder to the output site, if this folder is not found
-marmite will then copy the embedded static files to the static folder.
+When no theme is set, Marmite first writes the embedded static files (CSS, JS, fonts,
+colorschemes) to the output, then copies your `static/` folder on top. This means
+your files override the embedded defaults while keeping any embedded files you
+didn't replace.
+
+> [!WARNING]
+> If you override a core file like `marmite.css`, `search.js`, `pico.min.css`,
+> `marmite.js`, a font, or a colorscheme, Marmite will warn you when the embedded
+> version differs from yours. This can happen after upgrading Marmite, when the
+> embedded file contains fixes or improvements. To resolve the drift, review the
+> changes and either update your copy or delete it from your `static/` folder to
+> use the embedded version.
+
+When a theme is set, static files come entirely from the theme's `static/` folder
+and the embedded files are not used.
 
 ## URL 
 

--- a/src/site.rs
+++ b/src/site.rs
@@ -1,6 +1,6 @@
 use crate::config::{Author, Marmite};
 use crate::content::{check_for_duplicate_slugs, Content, ContentBuilder, GroupedContent, Kind};
-use crate::embedded::{generate_static, Templates, EMBEDDED_TERA};
+use crate::embedded::{generate_static, Templates, EMBEDDED_STATIC, EMBEDDED_TERA};
 use crate::gallery::Gallery;
 use crate::highlight::{self, MarmiteHighlighter};
 use crate::image_resize;
@@ -15,7 +15,7 @@ use core::str;
 use fs_extra::dir::{copy as dircopy, CopyOptions};
 use glob::glob;
 use hotwatch::{Event, EventKind, Hotwatch};
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use rayon::prelude::*;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -1663,6 +1663,40 @@ fn write_code_highlight_css(site: &Marmite, output_folder: &Arc<std::path::PathB
     }
 }
 
+const CORE_STATIC_FILES: &[&str] = &[
+    "marmite.css",
+    "marmite.js",
+    "search.js",
+    "pico.min.css",
+    "AtkinsonHyperlegibleNext-Regular.woff2",
+];
+
+fn is_core_static_file(name: &str) -> bool {
+    CORE_STATIC_FILES.contains(&name) || name.starts_with("colorschemes/")
+}
+
+fn check_static_drift(user_static_dir: &Path) {
+    for (name, embedded_data) in EMBEDDED_STATIC.iter() {
+        if !is_core_static_file(name) {
+            continue;
+        }
+        let user_file = user_static_dir.join(name);
+        if user_file.exists() {
+            if let Ok(user_data) = fs::read(&user_file) {
+                if user_data != *embedded_data {
+                    warn!(
+                        "Static file '{}' differs from the embedded version. \
+                         The embedded version may contain updates or fixes. \
+                         To use the embedded version, remove '{}' from your static folder.",
+                        name,
+                        user_file.display()
+                    );
+                }
+            }
+        }
+    }
+}
+
 #[allow(clippy::too_many_lines)]
 fn handle_static_artifacts(
     input_folder: &Path,
@@ -1671,9 +1705,12 @@ fn handle_static_artifacts(
     content_dir: &std::path::Path,
 ) {
     let static_source = site_data.site.get_static_path(input_folder);
-    if static_source.is_dir() {
+    let has_theme = site_data.site.theme.is_some();
+
+    if has_theme && static_source.is_dir() {
+        // Theme provides its own complete static files
         let mut options = CopyOptions::new();
-        options.overwrite = true; // Overwrite files if they already exist
+        options.overwrite = true;
 
         if let Err(e) = dircopy(&static_source, &**output_folder, &options) {
             error!("Failed to copy static directory: {e:?}");
@@ -1686,7 +1723,29 @@ fn handle_static_artifacts(
             &output_folder.display()
         );
     } else {
-        generate_static(&output_folder.join(site_data.site.static_path.clone()));
+        // No theme (or theme without static dir) - use embedded as base
+        let output_static = output_folder.join(site_data.site.static_path.clone());
+        generate_static(&output_static);
+
+        // Copy user's own static files on top if they exist
+        let user_static = input_folder.join(&site_data.site.static_path);
+        if user_static.is_dir() {
+            check_static_drift(&user_static);
+
+            let mut options = CopyOptions::new();
+            options.overwrite = true;
+
+            if let Err(e) = dircopy(&user_static, &**output_folder, &options) {
+                error!("Failed to copy user static directory: {e:?}");
+                process::exit(1);
+            }
+
+            info!(
+                "Copied '{}' on top of embedded static to '{}/'",
+                &user_static.display(),
+                &output_folder.display()
+            );
+        }
     }
 
     // Copy extra static folders if present

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -50,9 +50,66 @@ fn test_site_generation_with_static_files() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    // Verify static files were copied
+    // Verify user static files were copied
     assert!(output_dir.join("static").join("style.css").exists());
     assert!(output_dir.join("static").join("script.js").exists());
+
+    // Verify embedded static files are also present (merged)
+    assert!(output_dir.join("static").join("marmite.css").exists());
+    assert!(output_dir.join("static").join("marmite.js").exists());
+    assert!(output_dir.join("static").join("pico.min.css").exists());
+    assert!(output_dir.join("static").join("search.js").exists());
+}
+
+#[test]
+fn test_static_drift_warning_for_core_files() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_dir = temp_dir.path().join("input");
+    let output_dir = temp_dir.path().join("output");
+
+    fs::create_dir_all(&input_dir).unwrap();
+    fs::create_dir_all(input_dir.join("content")).unwrap();
+    fs::create_dir_all(input_dir.join("static")).unwrap();
+
+    let config_path = input_dir.join("marmite.yaml");
+    fs::write(&config_path, "name: Site").unwrap();
+
+    // Create a modified core file that differs from embedded
+    fs::write(
+        input_dir.join("static").join("search.js"),
+        "// my customized search",
+    )
+    .unwrap();
+
+    fs::write(input_dir.join("content").join("page.md"), "# Page").unwrap();
+
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--",
+            input_dir.to_str().unwrap(),
+            output_dir.to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute marmite");
+
+    assert!(output.status.success());
+
+    // The user's customized version should be in the output (user wins)
+    let output_search_js = fs::read_to_string(output_dir.join("static").join("search.js")).unwrap();
+    assert_eq!(output_search_js, "// my customized search");
+
+    // Embedded files the user didn't override should still be present
+    assert!(output_dir.join("static").join("marmite.css").exists());
+    assert!(output_dir.join("static").join("pico.min.css").exists());
+
+    // Drift warning should appear in stderr
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("search.js") && stderr.contains("differs from the embedded version"),
+        "Expected drift warning for search.js in stderr, got: {stderr}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- **Fixes static file handling**: when no theme is set and the user has a `static/` folder, embedded static files are now written first, then user files are copied on top. Previously, the user's folder replaced all embedded files, breaking the site if the user only provided a few custom files (e.g. just `foo.png`).
- **Adds drift warnings**: when a user overrides a core embedded file (`marmite.css`, `marmite.js`, `search.js`, `pico.min.css`, fonts, colorschemes) that differs from the embedded version, a `WARN` is logged so the user knows to review changes after a Marmite upgrade.
- **Theme behavior unchanged**: when a theme is set, its `static/` folder is used as-is (no embedded files).
- **Updates documentation** in getting-started, configuration-reference, themes-feature, and customizing-templates to describe the new merge behavior.
- **Adds draft release notes** for 0.3.1.

## Test plan

- [x] Existing test `test_site_generation_with_static_files` updated to verify both user and embedded files are present in output
- [x] New test `test_static_drift_warning_for_core_files` verifies user file wins, embedded files remain, and drift warning appears in stderr
- [x] All 286 tests pass
- [x] Manual test: create a project with `static/foo.png` only, verify `output/static/` contains both `foo.png` and all embedded files
- [x] Manual test: override `static/search.js` with custom content, verify drift warning appears in build output