### PR TITLE
fix: avoid panic on multi-byte UTF-8 chars in shortcode debug log

### DIFF
--- a/src/shortcodes.rs
+++ b/src/shortcodes.rs
@@ -209,9 +209,16 @@ impl ShortcodeProcessor {
     ) -> String {
         let mut result = html.to_string();
 
+        let preview_end = {
+            let mut end = html.len().min(1500);
+            while end > 0 && !html.is_char_boundary(end) {
+                end -= 1;
+            }
+            end
+        };
         debug!(
             "Searching for shortcode pattern in HTML (first 1500 chars): {}",
-            &html[..html.len().min(1500)]
+            &html[..preview_end]
         );
 
         for captures in self.pattern.captures_iter(html) {


### PR DESCRIPTION
## Summary

- The debug log in `process_shortcodes` truncates HTML content at byte index 1500 using `&html[..html.len().min(1500)]`, which panics when byte 1500 falls inside a multi-byte UTF-8 character.
- This started failing after the version bump from `0.3.0` to `0.3.1-dev` (commit 72f4864), which added 4 extra bytes per `site.name` occurrence in the rendered HTML `<head>`, shifting the 1500-byte cutoff into the middle of `ã` (from "Programação" in page titles).
- Fix uses `is_char_boundary()` to walk back to a safe UTF-8 boundary before slicing.

Failing CI run: https://github.com/rochacbruno/marmite/actions/runs/24789682151/job/72544310937

## Test plan

- [ ] CI build job passes (previously panicked on `issue-test-comunicacao-na-programacao-e-muito-importante-util.html`)
- [ ] Pages with non-ASCII content render correctly