### PR TITLE
fix: URL-decode percent-encoded hrefs before slugifying in wikilinks

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -15,6 +15,7 @@ use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 use url::Url;
+use urlencoding::decode as urldecode;
 
 pub fn append_references(content: &str, references_path: &Path) -> String {
     if references_path.exists() {
@@ -126,8 +127,8 @@ pub fn get_html_with_options(
     options.extension.description_lists = parser_options.extension.description_lists;
     options.extension.footnotes = parser_options.extension.footnotes;
     options.extension.greentext = parser_options.extension.greentext;
-    options.extension.header_ids = Some(String::new()); // Not configurable
-                                                        // options.extension.image_url_rewriter = TODO: implement this to point to a resized image
+    options.extension.header_id_prefix = Some(String::new());
+    // options.extension.image_url_rewriter = TODO: implement this to point to a resized image
     options.extension.multiline_block_quotes = parser_options.extension.multiline_block_quotes;
     options.extension.tagfilter = parser_options.extension.tagfilter;
     options.extension.shortcodes = parser_options.extension.shortcodes;
@@ -195,15 +196,18 @@ pub fn fix_internal_links(html: &str) -> String {
         }
 
         let new_href = if let Ok(parsed) = Url::parse(&format!("m://m/{href}")) {
-            let path = slug::slugify(
-                parsed
-                    .path()
-                    .trim_start_matches('/')
-                    .trim_end_matches(".md")
-                    .trim_end_matches(".html"),
-            );
+            let raw_path = parsed
+                .path()
+                .trim_start_matches('/')
+                .trim_end_matches(".md")
+                .trim_end_matches(".html");
+            let decoded_path = urldecode(raw_path).unwrap_or_else(|_| raw_path.into());
+            let path = slug::slugify(&*decoded_path);
             let fragment = match parsed.fragment() {
-                Some(f) => slug::slugify(f),
+                Some(f) => {
+                    let decoded_f = urldecode(f).unwrap_or_else(|_| f.into());
+                    slug::slugify(&*decoded_f)
+                }
                 None => String::new(),
             };
 

--- a/src/tests/parser.rs
+++ b/src/tests/parser.rs
@@ -366,6 +366,22 @@ fn test_fix_wikilinks_mixed_content() {
 }
 
 #[test]
+fn test_fix_internal_links_with_percent_encoded_spaces() {
+    let html = r#"<a href="Markdown%20Format" data-wikilink="true">Markdown Format</a>"#;
+    let expected = r#"<a href="markdown-format.html" data-wikilink="true">Markdown Format</a>"#;
+    assert_eq!(fix_internal_links(html), expected);
+}
+
+#[test]
+fn test_fix_internal_links_with_percent_encoded_spaces_and_fragment() {
+    let html =
+        r#"<a href="Markdown%20Format#Obsidian%20Links" data-wikilink="true">Markdown Format</a>"#;
+    let expected =
+        r#"<a href="markdown-format.html#obsidian-links" data-wikilink="true">Markdown Format</a>"#;
+    assert_eq!(fix_internal_links(html), expected);
+}
+
+#[test]
 fn test_decode_html_entities() {
     assert_eq!(decode_html_entities("Test &amp; Example"), "Test & Example");
     assert_eq!(decode_html_entities("&lt;tag&gt;"), "<tag>");


### PR DESCRIPTION
## Summary

- Comrak encodes spaces as `%20` in wikilink hrefs (e.g. `[[Markdown Format]]` becomes `href="Markdown%20Format"`). `slug::slugify` strips the `%` as a special character but keeps the digits, producing broken slugs like `markdown-20format.html` instead of `markdown-format.html`. Fixed by URL-decoding the href before slugifying, using the already-available `urlencoding` crate.
- Also applies to fragment portions of the href (e.g. `#Obsidian%20Links` was becoming `#obsidian-20links`).
- Fixes deprecated comrak field `header_ids` -> `header_id_prefix` (eliminates build warning after the comrak 0.52 bump).

## Test plan

- [x] Added `test_fix_internal_links_with_percent_encoded_spaces` - verifies href with `%20` produces correct slug
- [x] Added `test_fix_internal_links_with_percent_encoded_spaces_and_fragment` - verifies both path and fragment are decoded
- [x] All 288 existing tests pass
- [x] Clean build with no warnings