### PR TITLE
Publishes to `standard.site`

### DIFF
--- a/.agents/skills/marmite/SKILL.md
+++ b/.agents/skills/marmite/SKILL.md
@@ -77,6 +77,10 @@ marmite <folder> --set-theme https://github.com/user/marmite-theme
 marmite --skill-install                      # for standard agents (.agents/)
 marmite --skill-install-claude               # for Claude Code (.claude/skills/)
 marmite --skill-install --skill-install-claude  # both at once
+
+# Manage atproto / standard.site integration
+marmite <folder> atproto auth                # Authenticate with your PDS
+marmite <folder> atproto publish             # Publish posts to standard.site PDS
 ```
 
 ## Workflow: Start a New Project

--- a/.agents/skills/marmite/references/cli-reference.md
+++ b/.agents/skills/marmite/references/cli-reference.md
@@ -124,6 +124,21 @@ marmite --version
 marmite --help
 ```
 
+### AT Protocol / standard.site
+
+```bash
+# Authenticate with your PDS (Personal Data Server)
+# Requires ATPROTO_APP_PASSWORD env var and atproto.handle configured in marmite.yaml
+marmite [site_folder] atproto auth
+
+# Publish your blog posts to the PDS as site.standard.document records
+marmite [site_folder] atproto publish
+
+# Publish posts with options
+marmite [site_folder] atproto publish --force
+marmite [site_folder] atproto publish --dry-run
+```
+
 ## All Flags and Options
 
 ### Build Control

--- a/.agents/skills/marmite/references/config-reference.md
+++ b/.agents/skills/marmite/references/config-reference.md
@@ -104,6 +104,17 @@ shortcode_pattern: '\{%\s*(\w+)([^%]*)\s*%\}'
 
 When a theme is set, templates and static files are loaded from the theme folder instead of the project root.
 
+## AT Protocol standard.site
+
+Configure the AT Protocol standard.site publishing integration:
+
+```yaml
+atproto:
+  handle: "myhandle.bsky.social"                                   # Your AT Protocol handle
+  publication_uri: "at://did:plc:.../site.standard.publication/..."  # The publication AT-URI
+  publish_content: true                                            # Publish full markdown body text (default: true)
+```
+
 ## Authors
 
 ```yaml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3117,6 +3117,7 @@ dependencies = [
  "chrono",
  "clap",
  "comrak",
+ "dirs",
  "env_logger",
  "frontmatter-gen",
  "fs_extra",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
  "cipher",
  "cpubits",
@@ -1674,9 +1674,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
  "zeroize",
@@ -1802,11 +1802,11 @@ checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "cipher"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "inout",
 ]
 
@@ -1852,9 +1852,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "color_quant"
@@ -1906,6 +1906,35 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fc4bff745c9b4c7fb1e97b25d13153da2bc7796260141df62378998d070207f"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -1998,9 +2027,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -2123,9 +2152,9 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
  "zeroize",
 ]
@@ -2180,6 +2209,15 @@ dependencies = [
  "cfg-if",
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -2605,9 +2643,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -3033,6 +3071,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3058,11 +3102,11 @@ dependencies = [
 
 [[package]]
 name = "lzma-rust2"
-version = "0.16.2"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47bb1e988e6fb779cf720ad431242d3f03167c1b3f2b1aae7f1a94b2495b36ae"
+checksum = "ce716bf1a316f47a280fc76295f6495b5bea4752bca01c3b3885e101b1c23c02"
 dependencies = [
- "sha2",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -3089,6 +3133,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2 0.10.9",
+ "shrike",
  "slug",
  "tempfile",
  "tera",
@@ -3406,7 +3452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3901,7 +3947,7 @@ version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
  "walkdir",
 ]
 
@@ -4107,6 +4153,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "shellexpand"
 version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4120,6 +4177,19 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shrike"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b6bfef6bf65b74b8238ad6bd2227e07173b81b3e8664e68e32eab08159e5c20"
+dependencies = [
+ "data-encoding",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -4543,11 +4613,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64",
+ "cookie_store",
  "flate2",
  "log",
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
+ "serde",
+ "serde_json",
  "ureq-proto",
  "utf8-zero",
  "webpki-roots",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ tempfile = "3.24.0"
 arborium = { version = "2.18", default-features = false }
 shrike = { version = "0.1.1", default-features = false, features = ["syntax"] }
 sha2 = "0.10"
+dirs = "6.0.0"
 
 [features]
 # Enables every arborium grammar.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,14 @@ lazy_static = "1.5.0"
 indexmap = { version = "2.13.0", features = ["serde"] }
 rss = "2.0.13"
 rayon = "1.11.0"
-ureq = "3.1.4"
+ureq = { version = "3.1.4", features = ["json"] }
 zip = "8.6.0"
 urlencoding = "2.1.3"
 image = "0.25.9"
 tempfile = "3.24.0"
 arborium = { version = "2.18", default-features = false }
+shrike = { version = "0.1.1", default-features = false, features = ["syntax"] }
+sha2 = "0.10"
 
 [features]
 # Enables every arborium grammar.

--- a/example/ai/llms.txt
+++ b/example/ai/llms.txt
@@ -75,6 +75,7 @@ $ marmite myblog --serve
 - [Link Checker with Lychee](https://marmite.blog/how-to-run-a-link-checker-on-your-marmite-website.html): Checking for broken links
 - [Enabling Comments](https://marmite.blog/enabling-comments.html): Adding comment systems to your blog
 - [Draft Posts Guide](https://marmite.blog/how-to-use-draft-posts-in-marmite.html): Working with draft content and publishing workflow
+- [AT Protocol standard.site](https://marmite.blog/atproto-standard-site.html): Complete guide to publishing your Marmite blog posts to the decentralized AT Protocol
 
 ### Deployment
 
@@ -123,6 +124,7 @@ $ marmite myblog --serve
 - **Draft Content Management**: Special handling of draft posts with filtering from feeds and search
 - **Related Content**: Configurable related content and backlinks between posts
 - **Markdown Alerts**: Support for GitHub-style callouts and alert boxes in markdown
+- **AT Protocol Publishing**: Native support for publishing blog posts to standard.site and the decentralized AT Protocol with automatic well-known verification
 
 ## Agents
 

--- a/example/content/2024-11-26-marmite-command-line-interface.md
+++ b/example/content/2024-11-26-marmite-command-line-interface.md
@@ -498,7 +498,11 @@ Both flags can be combined to set up all agents in one command.
 $ marmite --help
 Marmite is the easiest static site generator.
 
-Usage: marmite [OPTIONS] [INPUT_FOLDER] [OUTPUT_FOLDER]
+Usage: marmite [OPTIONS] [INPUT_FOLDER] [OUTPUT_FOLDER] [COMMAND]
+
+Commands:
+  atproto  Manage atproto / standard.site integration
+  help     Print this message or the help of the given subcommand(s)
 
 Arguments:
   [INPUT_FOLDER]   Input folder containing markdown files

--- a/example/content/2025-07-10-20-31-29-configuration-reference.md
+++ b/example/content/2025-07-10-20-31-29-configuration-reference.md
@@ -53,7 +53,7 @@ authors:
       - ["Website", "https://johndoe.com"]
       - ["Twitter", "https://twitter.com/johndoe"]
       - ["GitHub", "https://github.com/johndoe"]
-  
+
   jane:
     name: "Jane Smith"
     avatar: "media/jane-avatar.jpg"
@@ -71,19 +71,19 @@ Configure content streams with friendly display names:
 streams:
   tutorial:
     display_name: "Python Tutorials"
-  
+
   guide:
     display_name: "User Guides"
-  
+
   news:
     display_name: "Latest News"
-  
+
   review:
     display_name: "Product Reviews"
 ```
 
 Streams help organize content beyond tags and create focused RSS feeds. Posts can be assigned to streams via:
-- Frontmatter: `stream: tutorial`  
+- Frontmatter: `stream: tutorial`
 - Filename patterns: `tutorial-2024-01-01-post-title.md`
 - S-pattern for pages: `guide-S-comprehensive-guide.md`
 
@@ -259,7 +259,7 @@ Access in templates:
 
 ### Comments System
 
-The recommended way of configuring comments is using the file `_comments.md`, see more on [[Enabling Comments]] page, but alternatively 
+The recommended way of configuring comments is using the file `_comments.md`, see more on [[Enabling Comments]] page, but alternatively
 you can set a `comments` section in the settings file:
 
 ```yaml
@@ -445,7 +445,7 @@ publish_urls_json: true
 When enabled, Marmite automatically generates a `urls.json` file containing all your site's URLs organized by content type. This file has the same structure as the `--show-urls` command output and includes:
 
 - Posts, pages, tags, authors, series, streams, and archive URLs
-- RSS and JSON feed URLs  
+- RSS and JSON feed URLs
 - Pagination page URLs
 - File mapping URLs
 - Summary with counts and metadata
@@ -478,7 +478,20 @@ file_mapping:
 
 See the [[File Mapping Feature]] documentation for detailed examples and use cases.
 
-## Markdown parser options 
+## [AT Protocol](https://atproto.com) [`standard.site`](https://standard.site)
+
+Publish your blog posts to atproto:
+
+```yaml
+atproto:
+  handle: "myhandle.bsky.social"
+  publication_uri: "at://did:plc:.../site.standard.publication/..."
+  publish_content: true
+```
+
+See the [[AT Protocol standard.site]] documentation for more details.
+
+## Markdown parser options
 
 Marmite also allows customizing the markdown parser, the options are described on [[Configurable Markdown Parser Options]]
 

--- a/example/content/2026-05-08-23-00-00-marmite-0-3-2-release-notes.md
+++ b/example/content/2026-05-08-23-00-00-marmite-0-3-2-release-notes.md
@@ -98,6 +98,17 @@ The `--skill`, `--skill-install`, and `--skill-install-claude` commands do not r
 
 For all other commands, the input folder remains required and behaves exactly as before.
 
+## New Feature: AT Protocol & standard.site Integration
+
+Marmite now supports native integration with the **AT Protocol** and the **standard.site** specification. This allows you to publish your blog posts to the decentralized social web while keeping your Marmite site as the canonical source.
+
+Key capabilities:
+- **Fully optional** and opt-in.
+- **CLI Subcommand**: All functionality is cleanly organized under the `marmite atproto` command (`marmite atproto auth` to authenticate and `marmite atproto publish` to push updates).
+- **Decentralized Endpoint Resolution**: Respects the protocol's decentralized nature: resolves handles via DNS or `.well-known` endpoints directly, finds your PDS using the PLC directory (`plc.directory`), and interacts directly with your PDS.
+- **Verification and Header Injection**: Automatically generates verification files under `/.well-known/site.standard.publication` and injects publication and document headers (`link` tags) inside HTML templates.
+- **Change Detection**: Tracks content hashes and last-published state dynamically to only publish new or modified posts.
+
 ## Upgrading
 
 To upgrade to Marmite 0.3.2:

--- a/example/content/2026-06-17-atproto-standard-site.md
+++ b/example/content/2026-06-17-atproto-standard-site.md
@@ -1,0 +1,125 @@
+---
+tags: docs, atproto, standard.site
+description: Complete guide to publishing your Marmite blog posts to the decentralized AT Protocol using the standard.site specification.
+---
+
+# AT Protocol standard.site
+
+Marmite natively supports publishing your blog posts using the decentralized [AT Protocol](https://atproto.com) and the [standard.site](https://standard.site) lexicons. This enables your posts to be discovered, read, and interacted with (e.g., inside the [Bluesky](https://bsky.app)) across the decentralized web while keeping your Marmite site as the canonical source.
+
+---
+
+## Setup & Configuration
+
+To enable the AT Protocol features, add the `atproto` configuration block to your `marmite.yaml`:
+
+```yaml
+name: "My Blog"
+url: "https://myblog.com"
+
+atproto:
+  handle: "myhandle.bsky.social"
+  publication_uri: "at://did:plc:.../site.standard.publication/..."
+  publish_content: true
+```
+
+
+| Name | Required | Description |
+|---|---|---|
+| `handle` | Yes | Your AT Protocol handle (e.g. `yourname.bsky.social` or a custom domain handle) |
+| `publication_uri` | Yes | The AT-URI of your publication. You should register this publication externally (e.g., using a client like [standard.horse](https://standard.horse), [std-pub](https://cuducos.tngl.io/std-pub), or the [`goat` CLI](https://github.com/bluesky-social/goat)) |
+| `publish_content` | No | If `true`, Marmite will strip HTML tags from your compiled markdown and publish the post body text up to 10,000 characters as `textContent` to the AT Protocol record (defaults to `true`) |
+
+---
+
+## Authentication
+
+Before publishing, you must authenticate Marmite with your <a href="https://atproto.com/guides/going-to-production#pds"><abbr title="Personal Data Server">PDS</abbr></a>.
+
+First, ensure `atproto.handle` is configured in your `marmite.yaml`.
+
+Next, create an _App Password_ for your account (e.g., in Bluesky go to _Settings, App Passwords_).
+
+Export the password in your environment:
+
+```bash
+export ATPROTO_APP_PASSWORD="xxxx-xxxx-xxxx-xxxx"
+```
+
+Finally, run the authentication subcommand pointing to your site's directory:
+
+```bash
+marmite <site_folder> atproto auth
+```
+
+Marmite will:
+*   Perform a decentralized DNS/HTTP lookup to resolve your handle to its Decentralized Identifier (DID).
+*   Query `plc.directory` to resolve your DID to your actual <abbr title="Personal Data Server">PDS</abbr> endpoint.
+*   Acquire an authentication session from your <abbr title="Personal Data Server">PDS</abbr> and save the credentials locally at `~/.config/marmite/credentials.json`.
+
+---
+
+## Local Site Build & Verification
+
+When you compile your site using `marmite build` or run the dev server with `marmite serve`, Marmite automatically takes care of domain-level and page-level standard.site verification:
+
+### Automatic `.well-known` Generation
+Marmite generates a verification file at:
+`/.well-known/site.standard.publication` in your output directory.
+This file contains your `publication_uri`. Indexers and clients check this file on your domain to verify that you indeed own the AT Protocol publication record.
+
+### Automatic Header Injection
+
+For the **homepage and pages**, the default templates automatically inject the publication discovery link:
+
+```html
+<link rel="site.standard.publication" href="at://did:plc:.../site.standard.publication/...">
+```
+
+For **posts**, Marmite reads the state mapping from your published records and automatically injects the document link into the header of each post:
+
+```html
+<link rel="site.standard.document" href="at://did:plc:.../site.standard.document/...">
+```
+
+---
+
+## Publishing Posts (`publish`)
+
+To publish your posts to your <abbr title="Personal Data Server">PDS</abbr>, run:
+
+```bash
+marmite <site_folder> atproto publish
+```
+
+Also, check `--help` for more options.
+
+That command:
+
+1. Gathers all valid markdown posts (excluding drafts).
+2. Computes a content hash of each post to detect modifications.
+3. Authenticates with your resolved <abbr title="Personal Data Server">PDS</abbr>.
+4. Performs `createRecord` (for new posts) or `putRecord` (for modified posts) under the `site.standard.document` collection in your repository.
+5. Saves the mapping of post slugs to AT-URIs inside `.marmite-atproto-state.json`.
+
+Subsequent site `marmite build` read this local state file and automatically inject the document AT-URIs into the compiled HTML heads.
+
+---
+
+## Customizing Templates (Advanced)
+
+If you are using a custom theme and want to manually inject standard.site tags, add the following to your HTML heads:
+
+### Base layout (`base.html` or similar):
+```html
+{% if site.atproto and site.atproto.publication_uri %}
+<link rel="site.standard.publication" href="{{ site.atproto.publication_uri }}">
+{% endif %}
+```
+
+### Content layout (`content.html` or similar):
+```html
+{% if content.at_uri %}
+<link rel="site.standard.document" href="{{ content.at_uri }}">
+{% endif %}
+```

--- a/example/content/2026-06-17-atproto-standard-site.md
+++ b/example/content/2026-06-17-atproto-standard-site.md
@@ -52,6 +52,14 @@ Finally, run the authentication subcommand pointing to your site's directory:
 marmite <site_folder> atproto auth
 ```
 
+### Custom PDS / Self-Hosting (Optional)
+
+If you are self-hosting your PDS or if the automatic endpoint resolution fails, you can explicitly override the PDS endpoint using the `ATPROTO_PDS_URL` environment variable before authenticating:
+
+```bash
+export ATPROTO_PDS_URL="https://my-custom-pds.com"
+```
+
 Marmite will:
 *   Perform a decentralized DNS/HTTP lookup to resolve your handle to its Decentralized Identifier (DID).
 *   Query `plc.directory` to resolve your DID to your actual <abbr title="Personal Data Server">PDS</abbr> endpoint.
@@ -98,7 +106,7 @@ That command:
 
 1. Gathers all valid markdown posts (excluding drafts).
 2. Computes a content hash of each post to detect modifications.
-3. Authenticates with your resolved <abbr title="Personal Data Server">PDS</abbr>.
+3. Authenticates with your <abbr title="Personal Data Server">PDS</abbr> (using the saved PDS URL or overridden via the `ATPROTO_PDS_URL` environment variable).
 4. Performs `createRecord` (for new posts) or `putRecord` (for modified posts) under the `site.standard.document` collection in your repository.
 5. Saves the mapping of post slugs to AT-URIs inside `.marmite-atproto-state.json`.
 

--- a/example/templates/base.html
+++ b/example/templates/base.html
@@ -21,6 +21,9 @@
     <link rel="me" href="{{site.extra.fediverse_verification}}">
     {% endif %}
     {% endblock %}
+    {% if site.atproto and site.atproto.publication_uri %}
+    <link rel="site.standard.publication" href="{{ site.atproto.publication_uri }}">
+    {% endif %}
     {%- block head %}
     <title>{% if title %}{{title}} | {%endif%}{{ site.name }}</title>
     <link rel="stylesheet" type="text/css" href="{{url_for(path='static/pico.min.css')}}">

--- a/example/templates/content.html
+++ b/example/templates/content.html
@@ -25,6 +25,9 @@
 {% endif %}
 
 {% include "json_ld_content.html" ignore missing%}
+{% if content.at_uri %}
+<link rel="site.standard.document" href="{{ content.at_uri }}">
+{% endif %}
 {% endblock %}
 
 {% block head %}

--- a/example/templates/content.html
+++ b/example/templates/content.html
@@ -25,13 +25,13 @@
 {% endif %}
 
 {% include "json_ld_content.html" ignore missing%}
-{% if content.at_uri %}
-<link rel="site.standard.document" href="{{ content.at_uri }}">
-{% endif %}
 {% endblock %}
 
 {% block head %}
 {{ super() }}
+{% if content.at_uri %}
+<link rel="site.standard.document" href="{{ content.at_uri }}">
+{% endif %}
 {% if not site.code_highlight or site.code_highlight.enabled %}
 <link rel="stylesheet" href="{{ url_for(path='static/arborium.css') }}" />
 {% endif %}

--- a/example/theme_template/templates/base.html
+++ b/example/theme_template/templates/base.html
@@ -32,6 +32,9 @@
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="{{site.name}}">
     {% endblock %}
+    {% if site.atproto and site.atproto.publication_uri %}
+    <link rel="site.standard.publication" href="{{ site.atproto.publication_uri }}">
+    {% endif %}
     {% if site.extra.fediverse_verification %}
     <link rel="me" href="{{site.extra.fediverse_verification}}">
     {% endif %}

--- a/example/theme_template/templates/content.html
+++ b/example/theme_template/templates/content.html
@@ -29,6 +29,9 @@
 
 {% block head %}
 {{ super() }}
+{% if content.at_uri %}
+<link rel="site.standard.document" href="{{ content.at_uri }}">
+{% endif %}
 {% if not site.code_highlight or site.code_highlight.enabled %}
 <link rel="stylesheet" href="{{ url_for(path='static/arborium.css') }}" />
 {% endif %}

--- a/src/atproto/auth.rs
+++ b/src/atproto/auth.rs
@@ -4,14 +4,23 @@ use crate::cli::Cli;
 use crate::site::Data;
 use std::env;
 
-pub fn auth(input_folder: &std::path::Path, _args: &Cli) -> Result<(), Box<dyn std::error::Error>> {
-    // 1. Read handle from marmite.yaml in input_folder
-    let config_path = input_folder.join("marmite.yaml");
+pub fn auth(input_folder: &std::path::Path, args: &Cli) -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Read handle from configuration file in input_folder
+    let config_path = if args.config.starts_with('.') || args.config.starts_with('/') {
+        std::path::PathBuf::from(&args.config)
+    } else {
+        input_folder.join(&args.config)
+    };
     if !config_path.exists() {
-        return Err(format!("No marmite.yaml found in folder '{}'.\n\
-                            Please run this command specifying the input folder that contains marmite.yaml.",
-                            input_folder.display()).into());
+        return Err(format!("No configuration file found at '{}'.\n\
+                            Please run this command specifying the input folder that contains the configuration file.",
+                            config_path.display()).into());
     }
+
+    let config_filename = config_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("marmite.yaml");
 
     let site_data = Data::from_file(&config_path);
     let handle = site_data
@@ -19,7 +28,9 @@ pub fn auth(input_folder: &std::path::Path, _args: &Cli) -> Result<(), Box<dyn s
         .atproto
         .as_ref()
         .and_then(|a| a.handle.as_ref())
-        .ok_or("atproto.handle must be configured in marmite.yaml to authenticate.")?;
+        .ok_or(format!(
+            "atproto.handle must be configured in {config_filename} to authenticate."
+        ))?;
 
     // 2. Read password from environment
     let password = env::var("ATPROTO_APP_PASSWORD").map_err(|_| {
@@ -31,34 +42,36 @@ pub fn auth(input_folder: &std::path::Path, _args: &Cli) -> Result<(), Box<dyn s
         )
     })?;
 
-    let pds_url = env::var("ATPROTO_PDS_URL").unwrap_or_else(|_| {
-        match client::resolve_pds_endpoint(handle) {
-            Ok(resolved) => resolved,
-            Err(e) => {
-                log::warn!("Could not resolve PDS endpoint for handle '{handle}': {e}. Falling back to default.");
-                "https://bsky.social".to_string()
-            }
-        }
-    });
+    // 3. Resolve PDS endpoint (return error instead of falling back to hardcoded default)
+    let pds_url = if let Ok(val) = env::var("ATPROTO_PDS_URL") {
+        val
+    } else {
+        client::resolve_pds_endpoint(handle).map_err(|e| {
+            format!(
+                "Could not resolve PDS endpoint for handle '{handle}': {e}.\n\
+                 If you are self-hosting or the resolution failed, you can set the ATPROTO_PDS_URL environment variable to override."
+            )
+        })?
+    };
 
-    // 3. Authenticate
+    // 4. Authenticate
     let session = client::create_session(&pds_url, handle, &password)
         .map_err(|e| format!("Authentication failed: {e}\nCheck your handle and app password."))?;
 
-    // 4. Save credentials
+    // 5. Save credentials
     credentials::save(&Credential {
         pds_url,
         identifier: handle.clone(),
         password,
     })?;
 
-    eprintln!(
+    log::info!(
         "Authenticated as @{}\nCredentials saved to {}",
         session.handle,
         credentials::credentials_path().display()
     );
 
-    // 5. Check for publication_uri
+    // 6. Check for publication_uri
     if site_data
         .site
         .atproto
@@ -66,14 +79,14 @@ pub fn auth(input_folder: &std::path::Path, _args: &Cli) -> Result<(), Box<dyn s
         .and_then(|a| a.publication_uri.as_ref())
         .is_some()
     {
-        eprintln!("\nPublication already configured in marmite.yaml.");
+        log::info!("\nPublication already configured in {config_filename}.");
         return Ok(());
     }
 
-    eprintln!(
-        "\nNo publication_uri found in marmite.yaml.\n\
+    log::info!(
+        "\nNo publication_uri found in {config_filename}.\n\
          Please register your publication externally (e.g. at https://standard.site or via Sequoia CLI)\n\
-         to obtain your publication AT-URI, then configure it in marmite.yaml:\n\n\
+         to obtain your publication AT-URI, then configure it in {config_filename}:\n\n\
          atproto:\n\
            handle: {handle}\n\
            publication_uri: at://did:plc:.../site.standard.publication/...\n"

--- a/src/atproto/auth.rs
+++ b/src/atproto/auth.rs
@@ -1,0 +1,83 @@
+use crate::atproto::client;
+use crate::atproto::credentials::{self, Credential};
+use crate::cli::Cli;
+use crate::site::Data;
+use std::env;
+
+pub fn auth(input_folder: &std::path::Path, _args: &Cli) -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Read handle from marmite.yaml in input_folder
+    let config_path = input_folder.join("marmite.yaml");
+    if !config_path.exists() {
+        return Err(format!("No marmite.yaml found in folder '{}'.\n\
+                            Please run this command specifying the input folder that contains marmite.yaml.",
+                            input_folder.display()).into());
+    }
+
+    let site_data = Data::from_file(&config_path);
+    let handle = site_data
+        .site
+        .atproto
+        .as_ref()
+        .and_then(|a| a.handle.as_ref())
+        .ok_or("atproto.handle must be configured in marmite.yaml to authenticate.")?;
+
+    // 2. Read password from environment
+    let password = env::var("ATPROTO_APP_PASSWORD").map_err(|_| {
+        concat!(
+            "ATPROTO_APP_PASSWORD env var is required.\n",
+            "Create an app password at: https://bsky.app/settings/app-passwords\n\n",
+            "Then set:\n",
+            "  export ATPROTO_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx"
+        )
+    })?;
+
+    let pds_url = env::var("ATPROTO_PDS_URL").unwrap_or_else(|_| {
+        match client::resolve_pds_endpoint(handle) {
+            Ok(resolved) => resolved,
+            Err(e) => {
+                log::warn!("Could not resolve PDS endpoint for handle '{handle}': {e}. Falling back to default.");
+                "https://bsky.social".to_string()
+            }
+        }
+    });
+
+    // 3. Authenticate
+    let session = client::create_session(&pds_url, handle, &password)
+        .map_err(|e| format!("Authentication failed: {e}\nCheck your handle and app password."))?;
+
+    // 4. Save credentials
+    credentials::save(&Credential {
+        pds_url,
+        identifier: handle.clone(),
+        password,
+    })?;
+
+    eprintln!(
+        "Authenticated as @{}\nCredentials saved to {}",
+        session.handle,
+        credentials::credentials_path().display()
+    );
+
+    // 5. Check for publication_uri
+    if site_data
+        .site
+        .atproto
+        .as_ref()
+        .and_then(|a| a.publication_uri.as_ref())
+        .is_some()
+    {
+        eprintln!("\nPublication already configured in marmite.yaml.");
+        return Ok(());
+    }
+
+    eprintln!(
+        "\nNo publication_uri found in marmite.yaml.\n\
+         Please register your publication externally (e.g. at https://standard.site or via Sequoia CLI)\n\
+         to obtain your publication AT-URI, then configure it in marmite.yaml:\n\n\
+         atproto:\n\
+           handle: {handle}\n\
+           publication_uri: at://did:plc:.../site.standard.publication/...\n"
+    );
+
+    Ok(())
+}

--- a/src/atproto/client.rs
+++ b/src/atproto/client.rs
@@ -1,0 +1,222 @@
+/// Minimal synchronous XRPC client backed by ureq.
+///
+/// Only implements the three calls needed for atproto publishing:
+/// - `com.atproto.server.createSession`
+/// - `com.atproto.repo.createRecord`
+/// - `com.atproto.repo.putRecord`
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Session {
+    pub access_jwt: String,
+    pub did: String,
+    pub handle: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RecordRef {
+    pub uri: String,
+}
+
+/// Authenticate with a PDS using an app-password.
+/// Calls `com.atproto.server.createSession`.
+pub fn create_session(
+    pds_url: &str,
+    identifier: &str,
+    password: &str,
+) -> Result<Session, Box<dyn std::error::Error>> {
+    #[derive(Serialize)]
+    struct Body<'a> {
+        identifier: &'a str,
+        password: &'a str,
+    }
+
+    let url = format!("{pds_url}/xrpc/com.atproto.server.createSession");
+    let body = Body {
+        identifier,
+        password,
+    };
+    let mut response = ureq::post(&url)
+        .send_json(&body)
+        .map_err(|e| format!("Authentication request failed: {e}"))?;
+
+    let session: Session = response
+        .body_mut()
+        .read_json()
+        .map_err(|e| format!("Failed to parse session response: {e}"))?;
+
+    Ok(session)
+}
+
+/// Create a new repository record.
+/// Calls `com.atproto.repo.createRecord`.
+pub fn create_record(
+    pds_url: &str,
+    access_jwt: &str,
+    repo: &str,
+    collection: &str,
+    record: &serde_json::Value,
+) -> Result<RecordRef, Box<dyn std::error::Error>> {
+    #[derive(Serialize)]
+    struct Body<'a> {
+        repo: &'a str,
+        collection: &'a str,
+        record: &'a serde_json::Value,
+        validate: bool,
+    }
+
+    let url = format!("{pds_url}/xrpc/com.atproto.repo.createRecord");
+    let body = Body {
+        repo,
+        collection,
+        record,
+        validate: false,
+    };
+    let mut response = ureq::post(&url)
+        .header("Authorization", &format!("Bearer {access_jwt}"))
+        .send_json(&body)
+        .map_err(|e| format!("createRecord request failed: {e}"))?;
+
+    let result: RecordRef = response
+        .body_mut()
+        .read_json()
+        .map_err(|e| format!("Failed to parse createRecord response: {e}"))?;
+
+    Ok(result)
+}
+
+/// Update an existing repository record.
+/// Calls `com.atproto.repo.putRecord`.
+pub fn put_record(
+    pds_url: &str,
+    access_jwt: &str,
+    repo: &str,
+    collection: &str,
+    rkey: &str,
+    record: &serde_json::Value,
+) -> Result<RecordRef, Box<dyn std::error::Error>> {
+    #[derive(Serialize)]
+    struct Body<'a> {
+        repo: &'a str,
+        collection: &'a str,
+        rkey: &'a str,
+        record: &'a serde_json::Value,
+        validate: bool,
+    }
+
+    let url = format!("{pds_url}/xrpc/com.atproto.repo.putRecord");
+    let body = Body {
+        repo,
+        collection,
+        rkey,
+        record,
+        validate: false,
+    };
+    let mut response = ureq::post(&url)
+        .header("Authorization", &format!("Bearer {access_jwt}"))
+        .send_json(&body)
+        .map_err(|e| format!("putRecord request failed: {e}"))?;
+
+    let result: RecordRef = response
+        .body_mut()
+        .read_json()
+        .map_err(|e| format!("Failed to parse putRecord response: {e}"))?;
+
+    Ok(result)
+}
+
+#[derive(Debug, Deserialize)]
+struct DidDocumentService {
+    id: String,
+    #[serde(rename = "type")]
+    service_type: String,
+    #[serde(rename = "serviceEndpoint")]
+    service_endpoint: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DidDocument {
+    service: Option<Vec<DidDocumentService>>,
+}
+
+/// Resolves an atproto handle to its PDS endpoint
+pub fn resolve_pds_endpoint(handle: &str) -> Result<String, Box<dyn std::error::Error>> {
+    // 1. Resolve handle to DID (via well-known or DNS)
+    let did = resolve_handle_to_did(handle)?;
+
+    // 2. Resolve DID to DID Document and find PDS
+    let pds = resolve_did_to_pds(&did)?;
+    Ok(pds)
+}
+
+fn resolve_handle_to_did(handle: &str) -> Result<String, Box<dyn std::error::Error>> {
+    // Try HTTPS .well-known lookup
+    let well_known_url = format!("https://{}/.well-known/atproto-did", handle);
+    if let Ok(mut resp) = ureq::get(&well_known_url).call() {
+        if resp.status().as_u16() == 200 {
+            if let Ok(body) = resp.body_mut().read_to_string() {
+                let did = body.trim().to_string();
+                if did.starts_with("did:") {
+                    return Ok(did);
+                }
+            }
+        }
+    }
+
+    // Try Cloudflare DNS-over-HTTPS JSON query for TXT record fallback
+    let dns_url = format!(
+        "https://cloudflare-dns.com/dns-query?name=_atproto.{}&type=TXT",
+        handle
+    );
+    if let Ok(mut resp) = ureq::get(&dns_url)
+        .header("Accept", "application/dns-json")
+        .call()
+    {
+        #[derive(Deserialize)]
+        struct DnsAnswer {
+            data: String,
+        }
+        #[derive(Deserialize)]
+        struct DnsResponse {
+            #[serde(rename = "Answer")]
+            answer: Option<Vec<DnsAnswer>>,
+        }
+
+        if let Ok(dns_resp) = resp.body_mut().read_json::<DnsResponse>() {
+            if let Some(answers) = dns_resp.answer {
+                for ans in answers {
+                    let txt = ans.data.trim_matches('"');
+                    if let Some(stripped) = txt.strip_prefix("did=") {
+                        return Ok(stripped.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    Err(format!("Could not resolve handle {} to a DID", handle).into())
+}
+
+fn resolve_did_to_pds(did: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let url = if did.starts_with("did:plc:") {
+        format!("https://plc.directory/{}", did)
+    } else if let Some(stripped) = did.strip_prefix("did:web:") {
+        format!("https://{}/.well-known/did.json", stripped)
+    } else {
+        return Err(format!("Unsupported DID method: {}", did).into());
+    };
+
+    let mut resp = ureq::get(&url).call()?;
+    let doc = resp.body_mut().read_json::<DidDocument>()?;
+    if let Some(services) = doc.service {
+        for service in services {
+            if service.service_type == "AtprotoPersonalDataServer"
+                || service.id.ends_with("#atproto_pds")
+            {
+                return Ok(service.service_endpoint);
+            }
+        }
+    }
+    Err("PDS endpoint not found in DID document".into())
+}

--- a/src/atproto/credentials.rs
+++ b/src/atproto/credentials.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
@@ -14,8 +15,9 @@ pub struct Credential {
 type CredentialsStore = HashMap<String, Credential>;
 
 fn credentials_dir() -> PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home).join(".config").join("marmite")
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("marmite")
 }
 
 pub fn credentials_path() -> PathBuf {
@@ -40,6 +42,7 @@ fn save_store(store: &CredentialsStore) -> Result<(), Box<dyn std::error::Error>
     let path = credentials_path();
     let json = serde_json::to_string_pretty(store)?;
     fs::write(&path, json)?;
+    #[cfg(unix)]
     fs::set_permissions(&path, fs::Permissions::from_mode(0o600))?;
     Ok(())
 }

--- a/src/atproto/credentials.rs
+++ b/src/atproto/credentials.rs
@@ -1,0 +1,65 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Credential {
+    pub pds_url: String,
+    pub identifier: String,
+    pub password: String,
+}
+
+type CredentialsStore = HashMap<String, Credential>;
+
+fn credentials_dir() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    PathBuf::from(home).join(".config").join("marmite")
+}
+
+pub fn credentials_path() -> PathBuf {
+    credentials_dir().join("credentials.json")
+}
+
+fn load_store() -> CredentialsStore {
+    let path = credentials_path();
+    if !path.exists() {
+        return HashMap::new();
+    }
+    let content = match fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return HashMap::new(),
+    };
+    serde_json::from_str(&content).unwrap_or_default()
+}
+
+fn save_store(store: &CredentialsStore) -> Result<(), Box<dyn std::error::Error>> {
+    let dir = credentials_dir();
+    fs::create_dir_all(&dir)?;
+    let path = credentials_path();
+    let json = serde_json::to_string_pretty(store)?;
+    fs::write(&path, json)?;
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o600))?;
+    Ok(())
+}
+
+pub fn save(cred: &Credential) -> Result<(), Box<dyn std::error::Error>> {
+    let mut store = load_store();
+    store.insert(cred.identifier.clone(), cred.clone());
+    save_store(&store)
+}
+
+pub fn load(identifier: &str) -> Option<Credential> {
+    let mut store = load_store();
+    store.remove(identifier)
+}
+
+pub fn load_any() -> Option<Credential> {
+    let store = load_store();
+    if store.len() == 1 {
+        store.into_values().next()
+    } else {
+        None
+    }
+}

--- a/src/atproto/mod.rs
+++ b/src/atproto/mod.rs
@@ -1,0 +1,19 @@
+pub mod auth;
+pub mod client;
+pub mod credentials;
+pub mod publish;
+
+use crate::cli::{AtprotoCommand, Cli};
+
+pub fn dispatch(cmd: &AtprotoCommand, args: &Cli) -> Result<(), Box<dyn std::error::Error>> {
+    let input_folder = args
+        .input_folder
+        .as_deref()
+        .ok_or("Input folder is required for atproto commands")?;
+    match cmd {
+        AtprotoCommand::Auth => auth::auth(input_folder, args),
+        AtprotoCommand::Publish { force, dry_run } => {
+            publish::publish(input_folder, *force, *dry_run, &args.config)
+        }
+    }
+}

--- a/src/atproto/publish.rs
+++ b/src/atproto/publish.rs
@@ -129,15 +129,7 @@ pub fn publish(
         })?;
 
     // 3. Authenticate
-    let pds_url = env::var("ATPROTO_PDS_URL").unwrap_or_else(|_| {
-        match client::resolve_pds_endpoint(handle) {
-            Ok(resolved) => resolved,
-            Err(e) => {
-                log::warn!("Could not resolve PDS endpoint for handle '{handle}': {e}. Falling back to default.");
-                "https://bsky.social".to_string()
-            }
-        }
-    });
+    let pds_url = env::var("ATPROTO_PDS_URL").unwrap_or(cred.pds_url.clone());
     let session = client::create_session(&pds_url, &cred.identifier, &cred.password)
         .map_err(|e| format!("Authentication failed: {e}"))?;
 
@@ -232,16 +224,11 @@ pub fn publish(
                     result.uri
                 }
                 None => {
-                    let result = client::create_record(
-                        &pds_url,
-                        &session.access_jwt,
-                        &session.did,
-                        "site.standard.document",
-                        &record,
+                    return Err(format!(
+                        "Could not parse record key (rkey) from AT-URI '{}' for post '{}'",
+                        entry.at_uri, post.slug
                     )
-                    .map_err(|e| format!("Failed to publish '{}': {e}", post.slug))?;
-                    published += 1;
-                    result.uri
+                    .into());
                 }
             }
         } else {

--- a/src/atproto/publish.rs
+++ b/src/atproto/publish.rs
@@ -1,0 +1,281 @@
+use crate::atproto::client;
+use crate::atproto::credentials;
+use crate::content::Content;
+use crate::re;
+use crate::site::{get_content_folder, Data};
+use chrono::Utc;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct StateEntry {
+    content_hash: String,
+    at_uri: String,
+    last_published: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct PublishState {
+    posts: HashMap<String, StateEntry>,
+}
+
+fn state_path(input_folder: &Path) -> PathBuf {
+    input_folder.join(".marmite-atproto-state.json")
+}
+
+fn load_state(input_folder: &Path) -> PublishState {
+    let path = state_path(input_folder);
+    if !path.exists() {
+        return PublishState::default();
+    }
+    fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+fn save_state(input_folder: &Path, state: &PublishState) -> Result<(), Box<dyn std::error::Error>> {
+    let json = serde_json::to_string_pretty(state)?;
+    fs::write(state_path(input_folder), json)?;
+    Ok(())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+fn strip_html(html: &str) -> String {
+    let re = Regex::new(re::MATCH_HTML_TAGS).unwrap_or_else(|_| Regex::new(r"<[^>]*>").unwrap());
+    re.replace_all(html, "").to_string()
+}
+
+/// Extract the rkey from an AT URI string (at://did/.../rkey).
+fn rkey_from_at_uri(at_uri: &str) -> Option<String> {
+    at_uri
+        .parse::<shrike::syntax::AtUri>()
+        .ok()
+        .and_then(|u| u.rkey().map(|r| r.to_string()))
+}
+
+fn collect_publishable_posts(input_folder: &Path, config_path: &Path) -> Vec<Content> {
+    let site_data = Data::from_file(config_path);
+    let content_dir = get_content_folder(&site_data.site, input_folder);
+    let fragments = HashMap::new();
+
+    WalkDir::new(&content_dir)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| {
+            let name = e.path().file_name().and_then(|n| n.to_str()).unwrap_or("");
+            let ext = e.path().extension().and_then(|x| x.to_str());
+            e.path().is_file() && ext == Some("md") && !name.starts_with('_')
+        })
+        .filter_map(|entry| {
+            Content::from_markdown(entry.path(), Some(&fragments), &site_data.site, None, None).ok()
+        })
+        .filter(|post| post.date.is_some() && post.stream.as_deref() != Some("draft"))
+        .collect()
+}
+
+pub fn publish(
+    input_folder: &Path,
+    force: bool,
+    dry_run: bool,
+    config_file: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config_path = input_folder.join(config_file);
+    let site_data = Data::from_file(&config_path);
+    let marmite = &site_data.site;
+
+    // 1. Validate atproto config
+    let atproto = marmite.atproto.as_ref().ok_or({
+        concat!(
+            "No atproto configuration found in marmite.yaml.\n",
+            "Add the following to get started:\n\n",
+            "  atproto:\n",
+            "    handle: yourhandle.bsky.social\n\n",
+            "Then run: marmite atproto auth"
+        )
+    })?;
+
+    let handle = atproto
+        .handle
+        .as_deref()
+        .ok_or("Add atproto.handle: yourhandle.bsky.social to marmite.yaml")?;
+
+    // Check publication_uri
+    let publication_uri = atproto
+        .publication_uri
+        .as_deref()
+        .ok_or("No publication found. Add atproto.publication_uri to marmite.yaml.")?;
+
+    // 2. Load credentials
+    let cred = credentials::load(handle)
+        .or_else(credentials::load_any)
+        .ok_or_else(|| {
+            format!(
+                "No credentials found for '{handle}'.\n\
+                 Run: marmite atproto auth\n\
+                 (set ATPROTO_APP_PASSWORD env var first)"
+            )
+        })?;
+
+    // 3. Authenticate
+    let pds_url = env::var("ATPROTO_PDS_URL").unwrap_or_else(|_| {
+        match client::resolve_pds_endpoint(handle) {
+            Ok(resolved) => resolved,
+            Err(e) => {
+                log::warn!("Could not resolve PDS endpoint for handle '{handle}': {e}. Falling back to default.");
+                "https://bsky.social".to_string()
+            }
+        }
+    });
+    let session = client::create_session(&pds_url, &cred.identifier, &cred.password)
+        .map_err(|e| format!("Authentication failed: {e}"))?;
+
+    // 4. Load state
+    let mut state = load_state(input_folder);
+
+    // 5. Collect publishable posts
+    let posts = collect_publishable_posts(input_folder, &config_path);
+
+    let mut published = 0usize;
+    let mut updated = 0usize;
+    let mut skipped = 0usize;
+
+    for post in &posts {
+        let source_path = match &post.source_path {
+            Some(p) => p.clone(),
+            None => continue,
+        };
+
+        // Hash raw file content for change detection
+        let raw_bytes = match fs::read(&source_path) {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("Warning: could not read {}: {e}", source_path.display());
+                continue;
+            }
+        };
+        let hash = sha256_hex(&raw_bytes);
+
+        let existing = state.posts.get(&post.slug);
+        if !force {
+            if let Some(entry) = existing {
+                if entry.content_hash == hash {
+                    skipped += 1;
+                    continue;
+                }
+            }
+        }
+
+        // Build document record
+        let published_at = post
+            .date
+            .map(|d| d.and_utc().to_rfc3339())
+            .unwrap_or_else(|| Utc::now().to_rfc3339());
+
+        let canonical_url = format!("{}/{}.html", marmite.url.trim_end_matches('/'), post.slug);
+
+        let mut record = serde_json::json!({
+            "$type": "site.standard.document",
+            "title": post.title,
+            "site": publication_uri,
+            "path": format!("/{}", post.slug),
+            "canonicalUrl": canonical_url,
+            "publishedAt": published_at,
+        });
+
+        if let Some(desc) = &post.description {
+            record["description"] = serde_json::Value::String(desc.clone());
+        }
+        if !post.tags.is_empty() {
+            record["tags"] = serde_json::json!(post.tags);
+        }
+        if atproto.publish_content {
+            let text: String = strip_html(&post.html).chars().take(10_000).collect();
+            record["textContent"] = serde_json::Value::String(text);
+        }
+
+        if dry_run {
+            let action = if existing.is_some() {
+                "update"
+            } else {
+                "publish"
+            };
+            eprintln!("[dry-run] {action}: {}", post.slug);
+            continue;
+        }
+
+        // Publish or update
+        let at_uri = if let Some(entry) = existing {
+            match rkey_from_at_uri(&entry.at_uri) {
+                Some(rkey) => {
+                    let result = client::put_record(
+                        &pds_url,
+                        &session.access_jwt,
+                        &session.did,
+                        "site.standard.document",
+                        &rkey,
+                        &record,
+                    )
+                    .map_err(|e| format!("Failed to update '{}': {e}", post.slug))?;
+                    updated += 1;
+                    result.uri
+                }
+                None => {
+                    let result = client::create_record(
+                        &pds_url,
+                        &session.access_jwt,
+                        &session.did,
+                        "site.standard.document",
+                        &record,
+                    )
+                    .map_err(|e| format!("Failed to publish '{}': {e}", post.slug))?;
+                    published += 1;
+                    result.uri
+                }
+            }
+        } else {
+            let result = client::create_record(
+                &pds_url,
+                &session.access_jwt,
+                &session.did,
+                "site.standard.document",
+                &record,
+            )
+            .map_err(|e| format!("Failed to publish '{}': {e}", post.slug))?;
+            published += 1;
+            result.uri
+        };
+
+        state.posts.insert(
+            post.slug.clone(),
+            StateEntry {
+                content_hash: hash,
+                at_uri,
+                last_published: Utc::now().to_rfc3339(),
+            },
+        );
+    }
+
+    if !dry_run {
+        save_state(input_folder, &state)?;
+    }
+
+    if dry_run {
+        eprintln!("[dry-run] done — no changes made");
+    } else {
+        eprintln!("Published {published}, updated {updated}, skipped {skipped} posts");
+    }
+
+    Ok(())
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,27 @@
 #![allow(clippy::struct_excessive_bools)]
-use clap::{Args, Parser};
+use clap::{Args, Parser, Subcommand};
 use std::path::PathBuf;
+
+/// atproto / standard.site subcommands
+#[derive(Subcommand, Debug, Clone)]
+pub enum AtprotoCommand {
+    /// Authenticate with your atproto PDS using app-password credentials.
+    ///
+    /// Reads atproto.handle from marmite.yaml and ATPROTO_APP_PASSWORD env var.
+    /// If no publication exists, prints the config needed in marmite.yaml.
+    Auth,
+
+    /// Publish posts to atproto as site.standard.document records.
+    Publish {
+        /// Force re-publish all posts, ignoring change detection
+        #[arg(long, short)]
+        force: bool,
+
+        /// Preview what would be published without making any changes
+        #[arg(long, short = 'n')]
+        dry_run: bool,
+    },
+}
 
 /// Command Line Argument Parser for Marmite CLI
 #[derive(Parser, Debug, Clone)]
@@ -94,6 +115,10 @@ pub struct Cli {
     /// Override configuration values from CLI arguments
     #[command(flatten)]
     pub configuration: Configuration,
+
+    /// Publish to atproto standard.site
+    #[command(subcommand)]
+    pub atproto: Option<AtprotoCommand>,
 }
 
 /// Create a new markdown file in the input folder

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,6 +23,14 @@ pub enum AtprotoCommand {
     },
 }
 
+/// Global CLI Subcommands
+#[derive(Subcommand, Debug, Clone)]
+pub enum CliSubcommand {
+    /// Manage atproto / standard.site integration
+    #[command(subcommand)]
+    Atproto(AtprotoCommand),
+}
+
 /// Command Line Argument Parser for Marmite CLI
 #[derive(Parser, Debug, Clone)]
 #[command(version, about, long_about = None)]
@@ -116,9 +124,9 @@ pub struct Cli {
     #[command(flatten)]
     pub configuration: Configuration,
 
-    /// Publish to atproto standard.site
+    /// Global subcommand
     #[command(subcommand)]
-    pub atproto: Option<AtprotoCommand>,
+    pub subcommand: Option<CliSubcommand>,
 }
 
 /// Create a new markdown file in the input folder

--- a/src/config.rs
+++ b/src/config.rs
@@ -301,6 +301,10 @@ pub struct Marmite {
     /// Skip image resizing during build (faster development builds)
     #[serde(default)]
     pub skip_image_resize: bool,
+
+    /// atproto standard.site publishing configuration
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub atproto: Option<AtprotoConfig>,
 }
 
 fn default_true() -> bool {
@@ -495,6 +499,17 @@ pub struct SeriesConfig {
 pub struct FileMapping {
     pub source: String,
     pub dest: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
+pub struct AtprotoConfig {
+    /// atproto handle (e.g. myhandle.bsky.social)
+    pub handle: Option<String>,
+    /// AT URI of the publication record
+    pub publication_uri: Option<String>,
+    /// Include markdown body as textContent in document records [default: true]
+    #[serde(default = "default_true")]
+    pub publish_content: bool,
 }
 
 /// Generates a default configuration file

--- a/src/content.rs
+++ b/src/content.rs
@@ -110,6 +110,7 @@ pub struct Content {
     pub next: Option<Box<Content>>,
     pub previous: Option<Box<Content>>,
     pub source_path: Option<std::path::PathBuf>,
+    pub at_uri: Option<String>,
 }
 
 impl Content {
@@ -226,6 +227,7 @@ impl Content {
             next: None,
             previous: None,
             source_path: Some(path.to_path_buf()),
+            at_uri: None,
         };
         Ok(content)
     }
@@ -252,6 +254,7 @@ pub struct ContentBuilder {
     toc: Option<String>,
     comments: Option<bool>,
     source_path: Option<std::path::PathBuf>,
+    at_uri: Option<String>,
 }
 
 #[allow(dead_code)]
@@ -350,6 +353,11 @@ impl ContentBuilder {
         self
     }
 
+    pub fn at_uri(mut self, at_uri: String) -> Self {
+        self.at_uri = Some(at_uri);
+        self
+    }
+
     pub fn build(self) -> Content {
         Content {
             title: self.title.unwrap_or_default(),
@@ -373,6 +381,7 @@ impl ContentBuilder {
             next: None,
             previous: None,
             source_path: self.source_path,
+            at_uri: self.at_uri,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,8 @@ fn determine_verbosity(args: &cli::Cli) -> u8 {
             || args.generate_config
             || args.init_site
             || args.skill_install
-            || args.skill_install_claude)
+            || args.skill_install_claude
+            || args.subcommand.is_some())
     {
         verbose = 1;
     }
@@ -75,8 +76,14 @@ fn get_config_path(input_folder: &Path, config: &str) -> PathBuf {
 
 #[allow(clippy::too_many_lines)]
 fn run_cli(args: cli::Cli) -> Result<(), Box<dyn std::error::Error>> {
+    let verbose = determine_verbosity(&args);
+
+    if let Err(e) = setup_logging(verbose, args.debug) {
+        eprintln!("Logger already initialized: {e:?}");
+    }
+
     // Handle atproto subcommands before anything else
-    if let Some(ref atproto_cmd) = args.atproto {
+    if let Some(cli::CliSubcommand::Atproto(ref atproto_cmd)) = args.subcommand {
         return atproto::dispatch(atproto_cmd, &args);
     }
 
@@ -84,11 +91,6 @@ fn run_cli(args: cli::Cli) -> Result<(), Box<dyn std::error::Error>> {
     let serve = args.serve;
     let watch = args.watch;
     let bind_address: &str = args.bind.as_str();
-    let verbose = determine_verbosity(&args);
-
-    if let Err(e) = setup_logging(verbose, args.debug) {
-        error!("Logger already initialized: {e:?}");
-    }
 
     if args.skill {
         match embedded::get_skill_content() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use std::{
     sync::Arc,
 };
 
+mod atproto;
 mod cli;
 mod config;
 mod content;
@@ -74,6 +75,11 @@ fn get_config_path(input_folder: &Path, config: &str) -> PathBuf {
 
 #[allow(clippy::too_many_lines)]
 fn run_cli(args: cli::Cli) -> Result<(), Box<dyn std::error::Error>> {
+    // Handle atproto subcommands before anything else
+    if let Some(ref atproto_cmd) = args.atproto {
+        return atproto::dispatch(atproto_cmd, &args);
+    }
+
     let cloned_args = Arc::new(args.clone());
     let serve = args.serve;
     let watch = args.watch;

--- a/src/site.rs
+++ b/src/site.rs
@@ -585,6 +585,36 @@ pub fn generate(
                 highlighter.as_deref(),
             );
 
+            // Load atproto state to populate at_uri on matching posts/pages
+            let state_path = moved_input_folder.join(".marmite-atproto-state.json");
+            if state_path.exists() {
+                if let Ok(state_str) = fs::read_to_string(&state_path) {
+                    if let Ok(state_json) = serde_json::from_str::<serde_json::Value>(&state_str) {
+                        if let Some(posts_obj) = state_json.get("posts").and_then(|p| p.as_object())
+                        {
+                            for post in &mut site_data.posts {
+                                if let Some(entry) = posts_obj.get(&post.slug) {
+                                    if let Some(at_uri) =
+                                        entry.get("at_uri").and_then(|u| u.as_str())
+                                    {
+                                        post.at_uri = Some(at_uri.to_string());
+                                    }
+                                }
+                            }
+                            for page in &mut site_data.pages {
+                                if let Some(entry) = posts_obj.get(&page.slug) {
+                                    if let Some(at_uri) =
+                                        entry.get("at_uri").and_then(|u| u.as_str())
+                                    {
+                                        page.at_uri = Some(at_uri.to_string());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             // Process galleries
             let media_path = content_folder.join(&site_data.site.media_path);
             site_data.galleries = crate::gallery::process_galleries(
@@ -661,6 +691,23 @@ pub fn generate(
             // Generate urls.json if enabled
             if site_data.site.publish_urls_json {
                 generate_urls_json(&site_data, &output_path);
+            }
+
+            // Generate standard.site verification file if configured
+            if let Some(atproto) = &site_data.site.atproto {
+                if let Some(pub_uri) = &atproto.publication_uri {
+                    let wk_dir = output_path.join(".well-known");
+                    if let Err(e) = fs::create_dir_all(&wk_dir) {
+                        error!("Failed to create .well-known directory: {e:?}");
+                    } else {
+                        let wk_file = wk_dir.join("site.standard.publication");
+                        if let Err(e) = fs::write(&wk_file, pub_uri) {
+                            error!("Failed to write site.standard.publication verification file: {e:?}");
+                        } else {
+                            info!("Generated /.well-known/site.standard.publication verification file");
+                        }
+                    }
+                }
             }
 
             let end_time = start_time.elapsed().as_secs_f64();

--- a/src/tests/main.rs
+++ b/src/tests/main.rs
@@ -58,6 +58,7 @@ fn create_test_cli(overrides: impl FnOnce(&mut cli::Cli)) -> cli::Cli {
             shortcode_pattern: None,
             skip_image_resize: None,
         },
+        atproto: None,
     };
     overrides(&mut args);
     args

--- a/src/tests/main.rs
+++ b/src/tests/main.rs
@@ -58,7 +58,7 @@ fn create_test_cli(overrides: impl FnOnce(&mut cli::Cli)) -> cli::Cli {
             shortcode_pattern: None,
             skip_image_resize: None,
         },
-        atproto: None,
+        subcommand: None,
     };
     overrides(&mut args);
     args

--- a/tests/basic_functionality.rs
+++ b/tests/basic_functionality.rs
@@ -140,3 +140,79 @@ fn test_show_urls_command() {
     assert!(stdout.contains("https://example.com/page2.html"));
     assert!(stdout.contains("https://example.com/index.html"));
 }
+
+#[test]
+fn test_standard_site_atproto_generation() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_dir = temp_dir.path().join("input");
+    let output_dir = temp_dir.path().join("output");
+
+    // Create input directory structure
+    fs::create_dir_all(&input_dir).unwrap();
+    fs::create_dir_all(input_dir.join("content")).unwrap();
+
+    // Create config file with atproto configured
+    let config_path = input_dir.join("marmite.yaml");
+    fs::write(
+        &config_path,
+        r#"name: Test ATProto Blog
+url: https://myblog.com
+atproto:
+  handle: test.bsky.social
+  publication_uri: at://did:plc:123/site.standard.publication/456
+"#,
+    )
+    .unwrap();
+
+    // Create a post
+    let content_path = input_dir.join("content").join("first-post.md");
+    fs::write(&content_path, "# First Post\n\nHello standard.site!").unwrap();
+
+    // Create a mock state file
+    let state_path = input_dir.join(".marmite-atproto-state.json");
+    fs::write(
+        &state_path,
+        r#"{"posts":{"first-post":{"content_hash":"abc","at_uri":"at://did:plc:123/site.standard.document/first-post","last_published":"2026-06-17T17:08:42Z"}}}"#
+    ).unwrap();
+
+    // Generate site using marmite binary
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--",
+            input_dir.to_str().unwrap(),
+            output_dir.to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute marmite");
+
+    assert!(
+        output.status.success(),
+        "Command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // 1. Verify verification file was generated under .well-known
+    let wk_file = output_dir
+        .join(".well-known")
+        .join("site.standard.publication");
+    assert!(wk_file.exists());
+    let wk_content = fs::read_to_string(&wk_file).unwrap();
+    assert_eq!(
+        wk_content.trim(),
+        "at://did:plc:123/site.standard.publication/456"
+    );
+
+    // 2. Verify base layout has the link rel="site.standard.publication" tag
+    let index_file = output_dir.join("index.html");
+    assert!(index_file.exists());
+    let index_content = fs::read_to_string(&index_file).unwrap();
+    assert!(index_content.contains(r#"<link rel="site.standard.publication" href="at://did:plc:123/site.standard.publication/456">"#));
+
+    // 3. Verify post has the link rel="site.standard.document" tag
+    let post_file = output_dir.join("first-post.html");
+    assert!(post_file.exists());
+    let post_content = fs::read_to_string(&post_file).unwrap();
+    assert!(post_content.contains(r#"<link rel="site.standard.document" href="at://did:plc:123/site.standard.document/first-post">"#));
+}


### PR DESCRIPTION
This PR suggests the integration with [atproto](https://atproto.com)'s [standard.site](https://standard.site) according to this [new page](https://github.com/cuducos/marmite/blob/atproto/example/content/2026-06-17-atproto-standard-site.md), also part of the PR.

Surely it is optional:

* requires a handle and publication URI at `marmite.yaml`
* has a separate sub-command `marmite atproto`

Users can basically ignore everything added by this PR if they don't want this feature; it is totally opt-in.

Thanks @stevedylandev for the inspiration from [Sequoia CLI](https://tangled.org/stevedylan.dev/sequoia) :pink_heart:  