### PR TITLE
Fix Chinese/CJK character tags generating duplicate entries

### DIFF
--- a/example/content/2026-06-24-chinese-tags.md
+++ b/example/content/2026-06-24-chinese-tags.md
@@ -1,0 +1,15 @@
+---
+tags:
+  - 你好
+  - 中文
+stream: issue-test
+---
+
+# Chinese Characters in Tags
+
+This post demonstrates that tags with Chinese characters work correctly.
+
+Each Chinese tag should generate its own separate tag page without duplicates.
+
+- 你好 (hello)
+- 中文 (Chinese)

--- a/src/content.rs
+++ b/src/content.rs
@@ -433,9 +433,9 @@ pub fn get_slug<'a>(frontmatter: &'a Frontmatter, path: &'a Path) -> String {
     let mut final_slug: String;
 
     if let Some(slug) = frontmatter.get("slug") {
-        final_slug = slug::slugify(slug.to_string());
+        final_slug = crate::slugify::slugify(slug.to_string());
     } else if let Some(title) = frontmatter.get("title") {
-        final_slug = slug::slugify(title.to_string());
+        final_slug = crate::slugify::slugify(title.to_string());
     } else {
         final_slug = path
             .file_stem()
@@ -701,7 +701,7 @@ pub fn check_for_duplicate_slugs(contents: &Vec<&Content>) -> Result<(), String>
 pub fn new(input_folder: &Path, text: &str, cli_args: &Arc<Cli>, config_path: &Path) {
     let content_folder = get_content_folder(&Data::from_file(config_path).site, input_folder);
     let mut path = content_folder.clone();
-    let slug = slug::slugify(text);
+    let slug = crate::slugify::slugify(text);
     if cli_args.create.page {
         path.push(format!("{slug}.md"));
     } else {

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -101,7 +101,7 @@ impl SyntaxHighlighterAdapter for MarmiteHighlighter {
 }
 
 fn normalize(name: &str) -> String {
-    slug::slugify(name)
+    crate::slugify::slugify(name)
 }
 
 fn theme_by_name(name: &str) -> Option<Theme> {

--- a/src/image_provider.rs
+++ b/src/image_provider.rs
@@ -45,12 +45,12 @@ fn download_picsum_image(
     }
 
     // Build URL: https://picsum.photos/seed/{slugified-site-name-post-slug-tags}/1200/300
-    let slugified_site_name = slug::slugify(&config.name);
+    let slugified_site_name = crate::slugify::slugify(&config.name);
     let tags_string = tags.join("-");
     let slugified_tags = if tags_string.is_empty() {
         String::new()
     } else {
-        format!("-{}", slug::slugify(&tags_string))
+        format!("-{}", crate::slugify::slugify(&tags_string))
     };
     let seed = format!("{slugified_site_name}-{slug}{slugified_tags}");
     let url = format!("https://picsum.photos/seed/{seed}/1200/300");

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod re;
 mod server;
 mod shortcodes;
 mod site;
+mod slugify;
 mod templates;
 mod tera_filter;
 mod tera_functions;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -75,7 +75,7 @@ pub fn get_table_of_contents_from_html(html: &str) -> String {
         let level = cap.get(1).map_or(0, |m| m.as_str().parse().unwrap_or(0));
         let title = cap.get(3).map_or("", |m| m.as_str());
         let slug = cap.get(2).map_or_else(
-            || format!("#{}", slug::slugify(title)),
+            || format!("#{}", crate::slugify::slugify(title)),
             |m| m.as_str().to_string(),
         );
 
@@ -202,11 +202,11 @@ pub fn fix_internal_links(html: &str) -> String {
                 .trim_end_matches(".md")
                 .trim_end_matches(".html");
             let decoded_path = urldecode(raw_path).unwrap_or_else(|_| raw_path.into());
-            let path = slug::slugify(&*decoded_path);
+            let path = crate::slugify::slugify(&*decoded_path);
             let fragment = match parsed.fragment() {
                 Some(f) => {
                     let decoded_f = urldecode(f).unwrap_or_else(|_| f.into());
-                    slug::slugify(&*decoded_f)
+                    crate::slugify::slugify(&*decoded_f)
                 }
                 None => String::new(),
             };

--- a/src/site.rs
+++ b/src/site.rs
@@ -122,7 +122,7 @@ impl Data {
             self.posts.push(content.clone());
             // tags
             for tag in content.tags.clone() {
-                let tag_slug = slug::slugify(&tag);
+                let tag_slug = crate::slugify::slugify(&tag);
                 // Store under slugified key (primary, used for URLs and new templates)
                 self.tag
                     .entry(tag_slug.clone())
@@ -217,16 +217,16 @@ impl Data {
         for tag in self
             .tag
             .iter()
-            .filter(|(key, _)| slug::slugify(key) == key.as_str())
+            .filter(|(key, _)| crate::slugify::slugify(key) == key.as_str())
         {
-            let tag_slug = format!("tag-{}.html", slug::slugify(tag.0));
+            let tag_slug = format!("tag-{}.html", crate::slugify::slugify(tag.0));
             self.generated_urls.add_url("tags", tag_slug);
 
             // Add pagination for tags
             let content_count = tag.1.len();
             if content_count > 0 {
                 // Always add -1 page (same as base page but with consistent naming)
-                let pagination_slug_1 = format!("tag-{}-1.html", slug::slugify(tag.0));
+                let pagination_slug_1 = format!("tag-{}-1.html", crate::slugify::slugify(tag.0));
                 self.generated_urls.add_url("pagination", pagination_slug_1);
 
                 // Add additional pagination pages if content exceeds pagination limit
@@ -234,7 +234,7 @@ impl Data {
                     let total_pages = content_count.div_ceil(self.site.pagination);
                     for page_num in 2..=total_pages {
                         let pagination_slug =
-                            format!("tag-{}-{}.html", slug::slugify(tag.0), page_num);
+                            format!("tag-{}-{}.html", crate::slugify::slugify(tag.0), page_num);
                         self.generated_urls.add_url("pagination", pagination_slug);
                     }
                 }
@@ -246,22 +246,26 @@ impl Data {
 
         // Add author pages and pagination
         for author in self.author.iter() {
-            let author_slug = format!("author-{}.html", slug::slugify(author.0));
+            let author_slug = format!("author-{}.html", crate::slugify::slugify(author.0));
             self.generated_urls.add_url("authors", author_slug);
 
             // Add pagination for authors
             let content_count = author.1.len();
             if content_count > 0 {
                 // Always add -1 page (same as base page but with consistent naming)
-                let pagination_slug_1 = format!("author-{}-1.html", slug::slugify(author.0));
+                let pagination_slug_1 =
+                    format!("author-{}-1.html", crate::slugify::slugify(author.0));
                 self.generated_urls.add_url("pagination", pagination_slug_1);
 
                 // Add additional pagination pages if content exceeds pagination limit
                 if content_count > self.site.pagination {
                     let total_pages = content_count.div_ceil(self.site.pagination);
                     for page_num in 2..=total_pages {
-                        let pagination_slug =
-                            format!("author-{}-{}.html", slug::slugify(author.0), page_num);
+                        let pagination_slug = format!(
+                            "author-{}-{}.html",
+                            crate::slugify::slugify(author.0),
+                            page_num
+                        );
                         self.generated_urls.add_url("pagination", pagination_slug);
                     }
                 }
@@ -274,22 +278,26 @@ impl Data {
 
         // Add series pages and pagination
         for series in self.series.iter() {
-            let series_slug = format!("series-{}.html", slug::slugify(series.0));
+            let series_slug = format!("series-{}.html", crate::slugify::slugify(series.0));
             self.generated_urls.add_url("series", series_slug);
 
             // Add pagination for series
             let content_count = series.1.len();
             if content_count > 0 {
                 // Always add -1 page (same as base page but with consistent naming)
-                let pagination_slug_1 = format!("series-{}-1.html", slug::slugify(series.0));
+                let pagination_slug_1 =
+                    format!("series-{}-1.html", crate::slugify::slugify(series.0));
                 self.generated_urls.add_url("pagination", pagination_slug_1);
 
                 // Add additional pagination pages if content exceeds pagination limit
                 if content_count > self.site.pagination {
                     let total_pages = content_count.div_ceil(self.site.pagination);
                     for page_num in 2..=total_pages {
-                        let pagination_slug =
-                            format!("series-{}-{}.html", slug::slugify(series.0), page_num);
+                        let pagination_slug = format!(
+                            "series-{}-{}.html",
+                            crate::slugify::slugify(series.0),
+                            page_num
+                        );
                         self.generated_urls.add_url("pagination", pagination_slug);
                     }
                 }
@@ -304,7 +312,7 @@ impl Data {
         for stream in self.stream.iter() {
             // Skip "index" stream as it's handled separately as the main index
             if stream.0 != "index" {
-                let stream_slug = format!("{}.html", slug::slugify(stream.0));
+                let stream_slug = format!("{}.html", crate::slugify::slugify(stream.0));
                 self.generated_urls.add_url("streams", stream_slug);
             }
 
@@ -313,7 +321,7 @@ impl Data {
                 let content_count = stream.1.len();
                 if content_count > 0 {
                     // Always add -1 page (same as base page but with consistent naming)
-                    let pagination_slug_1 = format!("{}-1.html", slug::slugify(stream.0));
+                    let pagination_slug_1 = format!("{}-1.html", crate::slugify::slugify(stream.0));
                     self.generated_urls.add_url("pagination", pagination_slug_1);
 
                     // Add additional pagination pages if content exceeds pagination limit
@@ -321,7 +329,7 @@ impl Data {
                         let total_pages = content_count.div_ceil(self.site.pagination);
                         for page_num in 2..=total_pages {
                             let pagination_slug =
-                                format!("{}-{}.html", slug::slugify(stream.0), page_num);
+                                format!("{}-{}.html", crate::slugify::slugify(stream.0), page_num);
                             self.generated_urls.add_url("pagination", pagination_slug);
                         }
                     }
@@ -378,13 +386,13 @@ impl Data {
         {
             // Stream feeds (includes index stream which covers main index feed)
             for stream in self.stream.iter() {
-                let feed_slug = format!("{}.rss", slug::slugify(stream.0));
+                let feed_slug = format!("{}.rss", crate::slugify::slugify(stream.0));
                 self.generated_urls.add_url("feeds", feed_slug);
             }
 
             // Series feeds
             for series in self.series.iter() {
-                let feed_slug = format!("series-{}.rss", slug::slugify(series.0));
+                let feed_slug = format!("series-{}.rss", crate::slugify::slugify(series.0));
                 self.generated_urls.add_url("feeds", feed_slug);
             }
 
@@ -393,15 +401,15 @@ impl Data {
             for tag in self
                 .tag
                 .iter()
-                .filter(|(key, _)| slug::slugify(key) == key.as_str())
+                .filter(|(key, _)| crate::slugify::slugify(key) == key.as_str())
             {
-                let feed_slug = format!("tag-{}.rss", slug::slugify(tag.0));
+                let feed_slug = format!("tag-{}.rss", crate::slugify::slugify(tag.0));
                 self.generated_urls.add_url("feeds", feed_slug);
             }
 
             // Author feeds
             for author in self.author.iter() {
-                let feed_slug = format!("author-{}.rss", slug::slugify(author.0));
+                let feed_slug = format!("author-{}.rss", crate::slugify::slugify(author.0));
                 self.generated_urls.add_url("feeds", feed_slug);
             }
 
@@ -416,13 +424,13 @@ impl Data {
         if self.site.json_feed {
             // Stream feeds (includes index stream which covers main index feed)
             for stream in self.stream.iter() {
-                let feed_slug = format!("{}.json", slug::slugify(stream.0));
+                let feed_slug = format!("{}.json", crate::slugify::slugify(stream.0));
                 self.generated_urls.add_url("feeds", feed_slug);
             }
 
             // Series feeds
             for series in self.series.iter() {
-                let feed_slug = format!("series-{}.json", slug::slugify(series.0));
+                let feed_slug = format!("series-{}.json", crate::slugify::slugify(series.0));
                 self.generated_urls.add_url("feeds", feed_slug);
             }
 
@@ -431,15 +439,15 @@ impl Data {
             for tag in self
                 .tag
                 .iter()
-                .filter(|(key, _)| slug::slugify(key) == key.as_str())
+                .filter(|(key, _)| crate::slugify::slugify(key) == key.as_str())
             {
-                let feed_slug = format!("tag-{}.json", slug::slugify(tag.0));
+                let feed_slug = format!("tag-{}.json", crate::slugify::slugify(tag.0));
                 self.generated_urls.add_url("feeds", feed_slug);
             }
 
             // Author feeds
             for author in self.author.iter() {
-                let feed_slug = format!("author-{}.json", slug::slugify(author.0));
+                let feed_slug = format!("author-{}.json", crate::slugify::slugify(author.0));
                 self.generated_urls.add_url("feeds", feed_slug);
             }
 
@@ -1129,6 +1137,7 @@ fn initialize_tera(input_folder: &Path, site_data: &Data) -> (Tera, Option<Short
         },
     );
     tera.register_filter("remove_draft", tera_filter::RemoveDraft);
+    tera.register_filter("slugify", tera_filter::Slugify);
 
     let templates_path = site_data.site.get_templates_path(input_folder);
     let mandatory_templates = ["base.html", "list.html", "group.html", "content.html"];
@@ -1336,7 +1345,7 @@ fn handle_stream_pages(
         .collect::<Vec<_>>()
         .par_iter()
         .map(|(stream, stream_contents)| -> Result<(), String> {
-            let stream_slug = slug::slugify(stream);
+            let stream_slug = crate::slugify::slugify(stream);
             let title = if *stream == "index" {
                 String::new()
             } else {
@@ -1409,7 +1418,7 @@ fn handle_series_pages(
         .collect::<Vec<_>>()
         .par_iter()
         .map(|(series, series_contents)| -> Result<(), String> {
-            let series_slug = format!("series-{}", slug::slugify(series));
+            let series_slug = format!("series-{}", crate::slugify::slugify(series));
             let title = site_data
                 .site
                 .series_content_title
@@ -1536,7 +1545,7 @@ fn handle_author_pages(
             };
             author_context.insert("author", &author);
 
-            let author_slug = slug::slugify(username);
+            let author_slug = crate::slugify::slugify(username);
             let mut author_posts = site_data
                 .posts
                 .iter()
@@ -2781,7 +2790,7 @@ fn handle_tag_pages(
         .iter()
         // IMPORTANT: Filter to only process slugified keys (for backward compatibility,
         // we store under both original and slugified keys, but only generate pages for slugified ones)
-        .filter(|(key, _)| slug::slugify(key) == **key)
+        .filter(|(key, _)| crate::slugify::slugify(key) == **key)
         .collect::<Vec<_>>()
         .par_iter()
         .map(|(tag_slug, tagged_contents)| -> Result<(), String> {
@@ -2794,7 +2803,7 @@ fn handle_tag_pages(
                     content
                         .tags
                         .iter()
-                        .find(|t| slug::slugify(t) == tag_slug.as_str())
+                        .find(|t| crate::slugify::slugify(t) == tag_slug.as_str())
                         .cloned()
                 })
                 .unwrap_or_else(|| (*tag_slug).clone());

--- a/src/slugify.rs
+++ b/src/slugify.rs
@@ -1,0 +1,44 @@
+/// Unicode-aware slugify wrapper.
+///
+/// Falls back to preserving non-Latin alphanumeric characters
+/// when the `slug` crate strips everything (e.g. CJK text).
+pub fn slugify<S: AsRef<str>>(text: S) -> String {
+    let text = text.as_ref();
+    let result = slug::slugify(text);
+    if !result.is_empty() {
+        return result;
+    }
+    unicode_slugify(text)
+}
+
+#[cfg(test)]
+pub(crate) fn unicode_slugify_for_test(text: &str) -> String {
+    unicode_slugify(text)
+}
+
+fn unicode_slugify(text: &str) -> String {
+    let mut slug = String::with_capacity(text.len());
+    let mut prev_was_sep = true;
+
+    for c in text.chars() {
+        if c.is_alphanumeric() {
+            for lc in c.to_lowercase() {
+                slug.push(lc);
+            }
+            prev_was_sep = false;
+        } else if (c.is_whitespace() || c == '_' || c == '-') && !prev_was_sep && !slug.is_empty() {
+            slug.push('-');
+            prev_was_sep = true;
+        }
+    }
+
+    if slug.ends_with('-') {
+        slug.pop();
+    }
+
+    slug
+}
+
+#[cfg(test)]
+#[path = "tests/slugify.rs"]
+mod tests;

--- a/src/tera_filter.rs
+++ b/src/tera_filter.rs
@@ -23,6 +23,21 @@ impl Filter for DefaultDateFormat {
     }
 }
 
+pub struct Slugify;
+
+impl Filter for Slugify {
+    fn filter(
+        &self,
+        value: &Value,
+        _: &std::collections::HashMap<String, Value>,
+    ) -> tera::Result<Value> {
+        let s = value
+            .as_str()
+            .ok_or_else(|| tera::Error::msg("Expected a string for slugify filter"))?;
+        to_value(crate::slugify::slugify(s)).map_err(tera::Error::from)
+    }
+}
+
 pub struct RemoveDraft;
 
 impl Filter for RemoveDraft {

--- a/src/tera_functions.rs
+++ b/src/tera_functions.rs
@@ -114,10 +114,28 @@ impl Function for Group {
             _ => return Err(tera::Error::msg("Invalid `kind` argument")),
         };
 
-        // Convert to vector for sorting
+        // Convert to vector for sorting.
+        // For tags, filter out backward-compat duplicate keys and recover original names.
         let mut group_list: Vec<(String, Vec<Content>)> = grouped_content
             .iter()
-            .map(|(name, posts)| (name.clone(), posts.clone()))
+            .filter(|(key, _)| kind != "tag" || crate::slugify::slugify(key) == key.as_str())
+            .map(|(name, posts)| {
+                if kind == "tag" {
+                    let original_name = posts
+                        .iter()
+                        .find_map(|content| {
+                            content
+                                .tags
+                                .iter()
+                                .find(|t| crate::slugify::slugify(t) == name.as_str())
+                                .cloned()
+                        })
+                        .unwrap_or_else(|| name.clone());
+                    (original_name, posts.clone())
+                } else {
+                    (name.clone(), posts.clone())
+                }
+            })
             .collect();
 
         // Sort based on kind and ord parameter

--- a/src/tests/slugify.rs
+++ b/src/tests/slugify.rs
@@ -1,0 +1,93 @@
+use super::*;
+
+#[test]
+fn test_latin_text() {
+    assert_eq!(slugify("Simple Text"), "simple-text");
+}
+
+#[test]
+fn test_accented_latin() {
+    assert_eq!(slugify("Comunicação"), "comunicacao");
+}
+
+#[test]
+fn test_chinese_produces_nonempty_slug() {
+    let slug = slugify("你好");
+    assert!(!slug.is_empty());
+}
+
+#[test]
+fn test_chinese_distinct_tags_produce_distinct_slugs() {
+    let slug1 = slugify("你好");
+    let slug2 = slugify("中文");
+    assert_ne!(slug1, slug2);
+    assert!(!slug1.is_empty());
+    assert!(!slug2.is_empty());
+}
+
+#[test]
+fn test_japanese_produces_nonempty_slug() {
+    let slug = slugify("日本語");
+    assert!(!slug.is_empty());
+}
+
+#[test]
+fn test_korean_produces_nonempty_slug() {
+    let slug = slugify("한국어");
+    assert!(!slug.is_empty());
+}
+
+#[test]
+fn test_empty_string() {
+    assert_eq!(slugify(""), "");
+}
+
+#[test]
+fn test_mixed_latin_and_cjk() {
+    let result = slugify("hello 你好");
+    assert!(!result.is_empty());
+}
+
+#[test]
+fn test_slugify_is_idempotent() {
+    let slug = slugify("你好");
+    assert_eq!(slugify(&slug), slug);
+}
+
+#[test]
+fn test_latin_unchanged_behavior() {
+    assert_eq!(
+        slugify("Text with Special Characters!@#"),
+        "text-with-special-characters"
+    );
+    assert_eq!(
+        slugify("Text    with    multiple    spaces"),
+        "text-with-multiple-spaces"
+    );
+    assert_eq!(slugify("Text_with_underscores"), "text-with-underscores");
+    assert_eq!(slugify("Text with numbers 123"), "text-with-numbers-123");
+}
+
+#[test]
+fn test_unicode_fallback_with_spaces() {
+    let result = unicode_slugify_for_test("你好 世界");
+    assert_eq!(result, "你好-世界");
+}
+
+#[test]
+fn test_unicode_fallback_trims_hyphens() {
+    let result = unicode_slugify_for_test("  你好  ");
+    assert_eq!(result, "你好");
+}
+
+#[test]
+fn test_unicode_fallback_collapses_separators() {
+    let result = unicode_slugify_for_test("你好   世界");
+    assert_eq!(result, "你好-世界");
+}
+
+#[test]
+fn test_unicode_fallback_strips_punctuation() {
+    let result = unicode_slugify_for_test("你好！世界");
+    assert!(!result.contains('！'));
+}


### PR DESCRIPTION
Closes #449

## Summary

- Centralizes all `slug::slugify()` calls through a new `src/slugify.rs` wrapper module with a Unicode fallback for scripts the slug crate cannot transliterate
- Filters backward-compat duplicate keys in the `Group` Tera function so non-ASCII tags no longer appear twice in the tag list
- Recovers the original tag name (e.g. "你好") for display while using the transliterated slug (e.g. "ni-hao") for URLs
- Overrides Tera's built-in `slugify` filter with the same wrapper for consistency between Rust code and templates

## Test plan

- [x] `mask fmt` and `mask check` pass clean
- [x] All 307 tests pass (272 unit + 35 integration), including 14 new slugify tests
- [x] Example site builds with Chinese-tagged content, producing separate `tag-ni-hao.html` and `tag-zhong-wen.html` pages
- [x] Tags page shows each Chinese tag exactly once with original characters as display name
- [x] Existing Portuguese accented tags (Comunicacao) still work correctly