### PR TITLE
feat: media organization via slug-based subfolders and @/ prefix

### DIFF
--- a/.agents/skills/marmite-development/SKILL.md
+++ b/.agents/skills/marmite-development/SKILL.md
@@ -383,11 +383,32 @@ pub static EMBEDDED_MY_ASSETS: LazyLock<Vec<(String, Vec<u8>)>> = LazyLock::new(
    - Detect stream from frontmatter or filename prefix
    - Generate slug from frontmatter, title, or filename
    - Convert markdown to HTML via comrak
+   - Post-process the HTML (fix internal links, replace `@/` media refs)
    - Process shortcodes if enabled
 3. Build taxonomy indexes (tags, authors, archive, streams, series)
 4. Resolve backlinks and related content
 5. Render Tera templates with content and site data
 6. Write HTML output, copy static/media, resize images
+
+### HTML post-processing over raw markdown rewriting
+
+When a feature needs to rewrite URLs, paths, or other content in the output, always operate on the rendered HTML rather than on the raw markdown before comrak processes it.
+
+Comrak turns markdown into HTML and applies its own transformations (wrapping images in `<figure>`, generating anchor links, rendering code fences into `<code>` blocks, etc.). A naive find-and-replace on the raw markdown cannot distinguish between content the user intends to render (an image `src`, a link `href`) and content that should be left literal (code blocks, inline code, plain prose). By the time HTML is produced, that distinction is already made - real attributes live in tags, and literal text is inside `<code>` or plain text nodes.
+
+Existing functions that follow this pattern:
+
+- `fix_internal_links()` in `parser.rs` - rewrites `<a href="...">` attributes to turn `.md` references into `.html` slugs. Runs at the end of `get_html_with_options()`.
+- `fix_wikilinks()` in `parser.rs` - rewrites `<a data-wikilink="true">` attributes to resolve wikilink targets. Called in `site.rs` after content is collected.
+- `fix_at_media_refs()` in `content.rs` - rewrites `src="@/..."` and `href="@/..."` to `src="media/{slug}/..."`. Runs after `get_html_with_options()` returns in `from_markdown()`.
+
+When implementing a new feature that needs to transform paths, URLs, or text in content output, follow the same approach:
+
+1. Let comrak convert markdown to HTML first.
+2. Write a regex that targets the specific HTML attribute or tag (e.g., `src="..."`, `href="..."`, `<a ... >`).
+3. Define the regex pattern as a constant in `re.rs` with a doc comment.
+4. Apply the replacement on the HTML string after `get_html_with_options()` returns.
+5. Test that the replacement does not affect code blocks or plain text containing the same pattern.
 
 ### CLI command routing
 

--- a/.agents/skills/marmite/SKILL.md
+++ b/.agents/skills/marmite/SKILL.md
@@ -462,6 +462,50 @@ image_provider: picsum
 
 Downloads a deterministic placeholder image as `{slug}.banner.jpg` for each post. Only applies to posts, not pages. Delete the downloaded image and rebuild to get a different one.
 
+## Workflow: Media Management
+
+### Directory Layout
+
+Place media files in `content/media/`. You can use flat files or organize per-content subfolders:
+
+```
+content/
+  media/
+    my-post.banner.jpg              # Flat: auto-discovered for slug "my-post"
+    my-post/                        # Subfolder: named after the slug
+      banner.jpg                    # Auto-discovered as banner image
+      card.png                      # Auto-discovered as card image
+      diagram.svg                   # Referenced via @/ in markdown
+      photo.jpg
+  2024-06-15-my-post.md
+```
+
+### Automatic Banner and Card Discovery
+
+Marmite looks for banner and card images in this order:
+
+1. Explicit `banner_image` / `card_image` in frontmatter (always wins)
+2. Flat file: `media/{slug}.banner.{ext}` or `media/{slug}.{ext}`
+3. Subfolder: `media/{slug}/banner.{ext}` or `media/{slug}/card.{ext}`
+4. First `<img>` in the rendered HTML (card image fallback)
+
+Flat files take precedence over subfolder files, so existing sites are unaffected by the subfolder feature.
+
+### The `@/` Shorthand
+
+Use `@/` in markdown images and links to reference files in the content's media subfolder. Marmite replaces `@/` with `media/{slug}/` in `src` and `href` attributes of the rendered HTML:
+
+```markdown
+![Sunset photo](@/sunset.jpg)
+[Download the PDF](@/report.pdf)
+```
+
+For a post with slug `my-post`, the above becomes `src="media/my-post/sunset.jpg"` and `href="media/my-post/report.pdf"`.
+
+The replacement only targets HTML attributes, so `@/` in plain text, code blocks, and fragment files (`_` prefixed) is never touched. The prefix respects the configured `media_path`.
+
+See `references/content-organization.md` for full media organization details.
+
 ## Workflow: Comments
 
 Add a comment system by creating `content/_comments.md`:

--- a/.agents/skills/marmite/SKILL.md
+++ b/.agents/skills/marmite/SKILL.md
@@ -506,6 +506,63 @@ The replacement only targets HTML attributes, so `@/` in plain text, code blocks
 
 See `references/content-organization.md` for full media organization details.
 
+### Image Galleries
+
+Marmite has a built-in gallery system for displaying collections of images with thumbnails, navigation, and full-screen viewing.
+
+**Setup:**
+
+1. Create a gallery folder inside `content/media/gallery/`:
+
+```
+content/media/gallery/summer2025/
+  sunset.jpg
+  beach.jpg
+  palm-trees.jpg
+  gallery.yaml          # Optional configuration
+```
+
+2. Use the gallery shortcode in any post or page:
+
+```markdown
+<!-- .gallery path=summer2025 -->
+<!-- .gallery path=summer2025 width=800 height=600 ord=desc -->
+```
+
+**Gallery configuration** (`gallery.yaml`, all fields optional):
+
+```yaml
+name: "Summer 2025 Vacation"
+ord: asc                        # asc (default) or desc
+cover: "sunset.jpg"             # Cover image (defaults to first image)
+images:                         # Per-image descriptions (supports HTML)
+  - filename: "sunset.jpg"
+    description: "Sunset at the beach"
+  - filename: "*"               # Catch-all for remaining images
+    description: "Vacation photos"
+```
+
+Description matching supports exact match, partial match, regex patterns, and `*` catch-all. Matched in order - first match wins.
+
+**Config options** in `marmite.yaml`:
+
+```yaml
+gallery_path: "gallery"           # Subfolder of media/ for galleries (default: "gallery")
+gallery_create_thumbnails: true   # Auto-generate thumbnails (default: true)
+gallery_thumb_size: 50            # Thumbnail size in pixels (default: 50)
+```
+
+**Template function** for custom gallery layouts:
+
+```html
+{% set gallery = get_gallery(path="summer2025") %}
+{% for item in gallery.files %}
+  <img src="media/gallery/summer2025/{{ item.image }}" alt="{{ item.description }}">
+{% endfor %}
+```
+
+The gallery interface includes thumbnail strip navigation, keyboard arrow keys, touch/swipe gestures, and responsive design. Image formats: JPG, PNG, WebP, GIF, BMP, TIFF, AVIF.
+
 ## Workflow: Comments
 
 Add a comment system by creating `content/_comments.md`:

--- a/.agents/skills/marmite/references/content-organization.md
+++ b/.agents/skills/marmite/references/content-organization.md
@@ -298,6 +298,33 @@ Place images in `content/media/` (or the path configured by `media_path`):
 
 Marmite copies the media folder to the output and optionally resizes images.
 
+#### Slug-based media subfolders
+
+Media files can be organized in subfolders named after the content's slug:
+
+```
+content/
+  media/
+    my-post/
+      banner.jpg       # Auto-discovered as banner image
+      card.png         # Auto-discovered as card image
+      photo.png        # Referenced via @/ in markdown
+  2024-01-15-my-post.md
+```
+
+Marmite checks `media/{slug}/banner.{ext}` and `media/{slug}/card.{ext}` for automatic image discovery. Flat files (`media/{slug}.banner.{ext}`) take precedence over subfolder files for backward compatibility.
+
+#### The `@/` shorthand
+
+Use `@/` in markdown image and link syntax to reference files in the content's media subfolder:
+
+```markdown
+![Photo](@/photo.png)          <!-- becomes media/{slug}/photo.png -->
+[Download PDF](@/report.pdf)   <!-- becomes media/{slug}/report.pdf -->
+```
+
+The replacement targets only `src` and `href` attributes in the rendered HTML, so `@/` in plain text, code blocks, and fragment files (`_` prefixed) is left untouched. The `@/` prefix respects the configured `media_path`.
+
 ### Static Assets
 
 Place CSS, JS, fonts, and other assets in `static/`:

--- a/.agents/skills/marmite/references/markdown-format.md
+++ b/.agents/skills/marmite/references/markdown-format.md
@@ -101,6 +101,17 @@ Images are wrapped in `<figure>` tags with captions by default (`figure_with_cap
 
 Place images in the `content/media/` folder (or the path configured by `media_path`).
 
+### `@/` shorthand for per-content media
+
+Use `@/` to reference files in a media subfolder named after the content's slug:
+
+```markdown
+![Photo](@/photo.png)
+[Download](@/file.pdf)
+```
+
+For a post with slug `my-post`, `@/photo.png` becomes `media/my-post/photo.png` in the rendered HTML. The replacement only targets `src` and `href` attributes - `@/` in plain text and code blocks is left untouched.
+
 ## Lists
 
 ### Unordered

--- a/example/ai/llms.txt
+++ b/example/ai/llms.txt
@@ -71,6 +71,7 @@ $ marmite myblog --serve
 - [Automatic Sitemap Generation](https://marmite.blog/automatic-sitemap-generation.html): Built-in sitemap.xml generation for better SEO with configurable options
 - [File Mapping Feature](https://marmite.blog/file-mapping-feature.html): Copy arbitrary files during site generation using configurable mappings
 - [Automatic Image Download](https://marmite.blog/automatic-image-download.html): Auto-generating banner images
+- [Media Organization](https://marmite.blog/media-organization.html): Slug-based media subfolders and @/ shorthand for per-content media files
 - [Markdown Source Publishing](https://marmite.blog/markdown-source-publishing.html): Publishing source files alongside HTML
 - [Link Checker with Lychee](https://marmite.blog/how-to-run-a-link-checker-on-your-marmite-website.html): Checking for broken links
 - [Enabling Comments](https://marmite.blog/enabling-comments.html): Adding comment systems to your blog

--- a/example/content/2026-06-25-14-00-00-marmite-0-3-3-release-notes.md
+++ b/example/content/2026-06-25-14-00-00-marmite-0-3-3-release-notes.md
@@ -1,0 +1,40 @@
+---
+title: Marmite 0.3.3 Release Notes
+slug: marmite-0-3-3-release-notes
+description: "Marmite 0.3.3 adds slug-based media subfolders and the @/ shorthand for per-content media files."
+tags: [release-notes, marmite, features, announcement]
+author: rochacbruno
+stream: draft
+date: 2026-06-25 14:00:00
+---
+
+## New Features
+
+### Media Organization with Slug-Based Subfolders (#149)
+
+Media files can now be organized in subfolders named after the content's slug. Marmite automatically discovers `banner.{ext}` and `card.{ext}` files inside `media/{slug}/` directories.
+
+```
+content/
+  media/
+    my-post/
+      banner.jpg       # Auto-discovered as banner image
+      card.png         # Auto-discovered as card image
+      photo.png        # Referenced via @/ in markdown
+  2024-01-15-my-post.md
+```
+
+Flat files (`media/my-post.banner.jpg`) still take precedence, so existing sites are unaffected.
+
+### `@/` Shorthand for Media References (#149)
+
+Use `@/` in markdown image and link syntax to reference files in the content's media subfolder:
+
+```markdown
+![Photo](@/photo.png)
+[Download PDF](@/report.pdf)
+```
+
+Marmite replaces `@/` with `media/{slug}/` in the rendered HTML. The replacement only targets `src` and `href` attributes, so `@/` in plain text, code blocks, and fragment files is left untouched.
+
+See the [Media Organization](media-organization.html) guide for details.

--- a/example/content/2026-06-25-media-organization.md
+++ b/example/content/2026-06-25-media-organization.md
@@ -1,0 +1,96 @@
+---
+title: "Media Organization with Slug-Based Subfolders"
+tags: ["docs", "features", "media", "images"]
+description: "Organize media files in per-content subfolders and reference them with the @/ shorthand in markdown"
+authors: ["rochacbruno"]
+---
+
+# Media Organization with Slug-Based Subfolders
+
+Marmite supports organizing media files in subfolders named after your content's slug. This keeps media tidy for sites with many images per post and provides a convenient `@/` shorthand for referencing those files.
+
+## Media Subfolder Discovery
+
+Previously, banner and card images had to live as flat files in `media/` with the slug as a filename prefix (e.g., `media/my-post.banner.jpg`). Now you can also place them in a subfolder named after the slug:
+
+```
+content/
+  media/
+    my-post/
+      banner.jpg
+      card.png
+      diagram.svg
+      photo.png
+  2024-01-15-my-post.md
+```
+
+Marmite checks the subfolder for `banner.{ext}` and `card.{ext}` files automatically. The lookup order is:
+
+1. `media/{slug}.banner.{ext}` (flat file - existing behavior, takes precedence)
+2. `media/{slug}/{kind}.{ext}` (subfolder - new)
+
+Existing sites using flat files are unaffected.
+
+## The `@/` Shorthand
+
+Inside markdown content, use `@/` to reference files in your content's media subfolder. Marmite replaces `@/` in image and link attributes with `media/{slug}/` in the rendered HTML.
+
+```markdown
+---
+title: My Post
+slug: my-post
+---
+
+Here is a photo from the trip:
+
+![Sunset](@/sunset.jpg)
+
+Download the [full resolution version](@/sunset-full.jpg).
+```
+
+The rendered HTML will contain `src="media/my-post/sunset.jpg"` and `href="media/my-post/sunset-full.jpg"`.
+
+### What gets replaced
+
+The `@/` replacement only applies to `src` and `href` attributes in the final HTML. It does **not** affect:
+
+- **Plain text** - Writing `@/` in a paragraph leaves it as-is
+- **Code blocks** - Documenting the feature with `` `@/example.png` `` or fenced code blocks works correctly
+- **Fragment files** - Files prefixed with `_` (like `_hero.md`) do not get `@/` replacement since they are shared across content and have no slug context
+
+### Custom media path
+
+If you configure a custom `media_path` in `marmite.yaml`, the `@/` shorthand uses it:
+
+```yaml
+media_path: assets
+```
+
+With this config, `@/photo.png` in a post with slug `my-post` becomes `assets/my-post/photo.png`.
+
+## Putting It Together
+
+A typical workflow for a media-heavy post:
+
+1. Create your post: `content/2024-06-15-travel-photos.md`
+2. Create the media subfolder: `content/media/travel-photos/`
+3. Place your images there: `banner.jpg`, `card.png`, `photo1.jpg`, `photo2.jpg`
+4. Reference images in markdown with `@/`:
+
+```markdown
+---
+title: Travel Photos
+slug: travel-photos
+date: 2024-06-15
+---
+
+![Beach at sunset](@/photo1.jpg)
+
+![Mountain view](@/photo2.jpg)
+```
+
+Marmite will:
+- Automatically discover `media/travel-photos/banner.jpg` as the banner image
+- Automatically discover `media/travel-photos/card.png` as the card image
+- Replace `@/photo1.jpg` with `media/travel-photos/photo1.jpg` in the rendered HTML
+- Copy the entire `media/travel-photos/` folder to the output directory

--- a/src/content.rs
+++ b/src/content.rs
@@ -129,11 +129,13 @@ impl Content {
         let file_content = fs::read_to_string(path).map_err(|e| e.to_string())?;
         let (frontmatter, raw_markdown) = parse_front_matter(&file_content)?;
         let (title, markdown_without_title) = get_title(&frontmatter, raw_markdown);
+        let slug = get_slug(&frontmatter, path);
 
         let is_fragment = path
             .file_name()
             .and_then(|name| name.to_str())
             .is_some_and(|s| s.starts_with('_'));
+
         let default_parser_options = crate::config::ParserOptions::default();
         let parser_options = site
             .markdown_parser
@@ -162,9 +164,14 @@ impl Content {
             get_html_with_options(&markdown_without_title, parser_options, highlighter)
         };
 
+        let html = if !is_fragment {
+            fix_at_media_refs(&html, &site.media_path, &slug)
+        } else {
+            html
+        };
+
         let description = get_description(&frontmatter);
         let tags = get_tags(&frontmatter);
-        let slug = get_slug(&frontmatter, path);
         let date = get_date(&frontmatter, path);
         let extra = frontmatter.get("extra").map(std::borrow::ToOwned::to_owned);
         let links_to = get_links_to(&html);
@@ -813,6 +820,15 @@ fn find_matching_file(
                 return Some(image_filename.clone());
             }
         }
+        let slug_subfolder = media_path.join(slug);
+        if slug_subfolder.is_dir() {
+            for subfolder_filename in [format!("{kind}.{ext}"), format!("{slug}.{ext}")] {
+                let file_path = slug_subfolder.join(&subfolder_filename);
+                if file_path.exists() {
+                    return Some(format!("{media_folder_name}/{slug}/{subfolder_filename}"));
+                }
+            }
+        }
     }
     None
 }
@@ -851,6 +867,16 @@ fn get_banner_image(
         }
     }
     None
+}
+
+/// Replace `@/` references in rendered HTML `src` and `href` attributes
+/// with the slug-specific media path.
+/// Operates on final HTML so code blocks and plain text are not affected.
+fn fix_at_media_refs(html: &str, media_path: &str, slug: &str) -> String {
+    let re =
+        Regex::new(re::REPLACE_AT_MEDIA_REF_IN_HTML).expect("At-media HTML regex should compile");
+    let replacement = format!("${{attr}}=\"{media_path}/{slug}/");
+    re.replace_all(html, replacement.as_str()).into_owned()
 }
 
 #[cfg(test)]

--- a/src/image_resize.rs
+++ b/src/image_resize.rs
@@ -284,7 +284,7 @@ fn is_banner_image(path: &Path) -> bool {
         return false;
     };
 
-    filename.ends_with(".banner") || filename.contains(".banner.")
+    filename == "banner" || filename.ends_with(".banner") || filename.contains(".banner.")
 }
 
 /// Open an image and apply EXIF orientation to the pixel data.

--- a/src/re.rs
+++ b/src/re.rs
@@ -100,4 +100,11 @@ pub const CAPTURE_STREAM_FROM_S_FILENAME: &str = r"^([a-zA-Z0-9]+)-S-";
 /// Used for parsing dates from content metadata
 pub const CAPTURE_DATE_PREFIX_FROM_TEXT: &str = r"^\d{4}-\d{2}-\d{2}( \d{2}:\d{2}(:\d{2})?)?";
 
+// === Content Path Patterns ===
+
+/// Matches @/ at the start of src or href attribute values in HTML tags
+/// Captures: 1) the attribute name (src or href)
+/// Used for replacing @/ with media/{slug}/ in rendered HTML
+pub const REPLACE_AT_MEDIA_REF_IN_HTML: &str = r#"(?P<attr>src|href)="@/"#;
+
 // === Text Processing Patterns ===

--- a/src/tests/content.rs
+++ b/src/tests/content.rs
@@ -4,6 +4,7 @@ use chrono::NaiveDate;
 use frontmatter_gen::{Frontmatter, Value};
 use std::fs;
 use std::path::Path;
+use tempfile::TempDir;
 
 #[test]
 fn test_extract_stream_from_date_pattern() {
@@ -642,4 +643,193 @@ fn test_get_content_with_empty_file() {
     let result = Content::from_markdown(path, None, &Marmite::default(), None, None).unwrap();
     assert_eq!(result.slug, "test_get_content_with_empty_file".to_string());
     fs::remove_file(path).unwrap();
+}
+
+#[test]
+fn test_find_matching_file_subfolder_banner() {
+    let temp_dir = TempDir::new().unwrap();
+    let content_dir = temp_dir.path();
+    let media_dir = content_dir.join("media").join("test-slug");
+    fs::create_dir_all(&media_dir).unwrap();
+    fs::write(media_dir.join("banner.png"), b"fake image").unwrap();
+
+    let dummy_file = content_dir.join("test.md");
+    fs::write(&dummy_file, "").unwrap();
+
+    let result = find_matching_file("test-slug", &dummy_file, "banner", &["png", "jpg"], "media");
+    assert_eq!(result, Some("media/test-slug/banner.png".to_string()));
+}
+
+#[test]
+fn test_find_matching_file_subfolder_card() {
+    let temp_dir = TempDir::new().unwrap();
+    let content_dir = temp_dir.path();
+    let media_dir = content_dir.join("media").join("test-slug");
+    fs::create_dir_all(&media_dir).unwrap();
+    fs::write(media_dir.join("card.jpg"), b"fake image").unwrap();
+
+    let dummy_file = content_dir.join("test.md");
+    fs::write(&dummy_file, "").unwrap();
+
+    let result = find_matching_file("test-slug", &dummy_file, "card", &["png", "jpg"], "media");
+    assert_eq!(result, Some("media/test-slug/card.jpg".to_string()));
+}
+
+#[test]
+fn test_find_matching_file_flat_takes_precedence_over_subfolder() {
+    let temp_dir = TempDir::new().unwrap();
+    let content_dir = temp_dir.path();
+    let media_dir = content_dir.join("media");
+    fs::create_dir_all(media_dir.join("test-slug")).unwrap();
+    fs::write(media_dir.join("test-slug.banner.png"), b"flat").unwrap();
+    fs::write(media_dir.join("test-slug").join("banner.png"), b"subfolder").unwrap();
+
+    let dummy_file = content_dir.join("test.md");
+    fs::write(&dummy_file, "").unwrap();
+
+    let result = find_matching_file("test-slug", &dummy_file, "banner", &["png"], "media");
+    assert_eq!(
+        result,
+        Some("media/test-slug.banner.png".to_string()),
+        "Flat file should take precedence over subfolder"
+    );
+}
+
+#[test]
+fn test_find_matching_file_subfolder_slug_named() {
+    let temp_dir = TempDir::new().unwrap();
+    let content_dir = temp_dir.path();
+    let media_dir = content_dir.join("media").join("my-post");
+    fs::create_dir_all(&media_dir).unwrap();
+    fs::write(media_dir.join("my-post.jpg"), b"fake image").unwrap();
+
+    let dummy_file = content_dir.join("test.md");
+    fs::write(&dummy_file, "").unwrap();
+
+    let result = find_matching_file("my-post", &dummy_file, "card", &["png", "jpg"], "media");
+    assert_eq!(result, Some("media/my-post/my-post.jpg".to_string()));
+}
+
+#[test]
+fn test_find_matching_file_subfolder_nonexistent() {
+    let temp_dir = TempDir::new().unwrap();
+    let content_dir = temp_dir.path();
+    fs::create_dir_all(content_dir.join("media")).unwrap();
+
+    let dummy_file = content_dir.join("test.md");
+    fs::write(&dummy_file, "").unwrap();
+
+    let result = find_matching_file(
+        "no-such-slug",
+        &dummy_file,
+        "banner",
+        &["png", "jpg"],
+        "media",
+    );
+    assert_eq!(result, None);
+}
+
+#[test]
+fn test_at_prefix_replacement_in_content() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("2024-01-01-my-post.md");
+    let content = "---\ntitle: My Post\nslug: my-post\ndate: 2024-01-01\n---\n![](@/photo.png)\n";
+    fs::write(&path, content).unwrap();
+
+    let result = Content::from_markdown(&path, None, &Marmite::new(), None, None).unwrap();
+    assert!(
+        result.html.contains("media/my-post/photo.png"),
+        "Expected @/ to be replaced with media/my-post/, got: {}",
+        result.html
+    );
+}
+
+#[test]
+fn test_at_prefix_replacement_multiple_occurrences() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("2024-01-01-my-post.md");
+    let content =
+        "---\ntitle: My Post\nslug: my-post\ndate: 2024-01-01\n---\n![](@/a.png)\n\n[PDF](@/doc.pdf)\n";
+    fs::write(&path, content).unwrap();
+
+    let result = Content::from_markdown(&path, None, &Marmite::new(), None, None).unwrap();
+    assert!(
+        result.html.contains("media/my-post/a.png"),
+        "got: {}",
+        result.html
+    );
+    assert!(
+        result.html.contains("media/my-post/doc.pdf"),
+        "got: {}",
+        result.html
+    );
+}
+
+#[test]
+fn test_at_prefix_no_replacement_in_fragments() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("_fragment.md");
+    let content = "---\ntitle: Fragment\n---\n![](@/should-stay.png)\n";
+    fs::write(&path, content).unwrap();
+
+    let result = Content::from_markdown(&path, None, &Marmite::new(), None, None).unwrap();
+    assert!(
+        result.html.contains("@/should-stay.png"),
+        "Fragments should not have @/ replaced, got: {}",
+        result.html
+    );
+}
+
+#[test]
+fn test_at_prefix_with_custom_media_path() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("2024-01-01-my-post.md");
+    let content = "---\ntitle: My Post\nslug: my-post\ndate: 2024-01-01\n---\n![](@/photo.png)\n";
+    fs::write(&path, content).unwrap();
+
+    let mut config = Marmite::new();
+    config.media_path = "assets".to_string();
+
+    let result = Content::from_markdown(&path, None, &config, None, None).unwrap();
+    assert!(
+        result.html.contains("assets/my-post/photo.png"),
+        "Expected @/ to use custom media_path 'assets', got: {}",
+        result.html
+    );
+}
+
+#[test]
+fn test_at_prefix_not_replaced_in_plain_text() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("2024-01-01-my-post.md");
+    let content =
+        "---\ntitle: My Post\nslug: my-post\ndate: 2024-01-01\n---\nHello, this is my symbol @/ and should not be replaced\n";
+    fs::write(&path, content).unwrap();
+
+    let result = Content::from_markdown(&path, None, &Marmite::new(), None, None).unwrap();
+    assert!(
+        result.html.contains("@/"),
+        "Plain text @/ should not be replaced, got: {}",
+        result.html
+    );
+    assert!(
+        !result.html.contains("media/my-post/"),
+        "Plain text @/ should not become a media path, got: {}",
+        result.html
+    );
+}
+
+#[test]
+fn test_at_prefix_not_replaced_in_code_block() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("2024-01-01-my-post.md");
+    let content = "---\ntitle: My Post\nslug: my-post\ndate: 2024-01-01\n---\nHere is how you use it:\n\n```markdown\n![](@/foo.png)\n```\n";
+    fs::write(&path, content).unwrap();
+
+    let result = Content::from_markdown(&path, None, &Marmite::new(), None, None).unwrap();
+    assert!(
+        !result.html.contains("media/my-post/foo.png"),
+        "Code block @/ should not be replaced, got: {}",
+        result.html
+    );
 }

--- a/src/tests/image_resize.rs
+++ b/src/tests/image_resize.rs
@@ -225,6 +225,8 @@ fn test_is_vector_or_icon_image() {
 fn test_is_banner_image() {
     assert!(is_banner_image(Path::new("post.banner.jpg")));
     assert!(is_banner_image(Path::new("my-post.banner.png")));
+    assert!(is_banner_image(Path::new("banner.jpg")));
+    assert!(is_banner_image(Path::new("banner.png")));
     assert!(!is_banner_image(Path::new("regular-image.jpg")));
     assert!(!is_banner_image(Path::new("banner-style.jpg")));
 }


### PR DESCRIPTION
## Summary

- **Media subfolder discovery**: `find_matching_file()` now searches `media/{slug}/banner.{ext}` and `media/{slug}/card.{ext}` (after existing flat-file patterns, so backward compatible)
- **`@/` prefix replacement**: Writing `![](@/photo.png)` in markdown produces `<img src="media/{slug}/photo.png">` in the rendered HTML. Replacement targets `src`/`href` attributes in final HTML, so code blocks and plain text are not affected
- **Banner detection**: `is_banner_image()` recognizes bare `banner.{ext}` filenames in subfolders for correct resize behavior

## Test plan

- [x] `mask fmt` and `mask check` pass clean
- [x] All 283 unit tests pass (11 new tests added)
- [x] All 41 integration tests pass
- [x] Flat-file precedence verified (existing sites unaffected)
- [x] `@/` in code blocks and plain text verified as not replaced
- [x] `@/` in fragments (`_` prefixed files) verified as not replaced
- [x] Custom `media_path` config respected

Closes #149