### PR TITLE
Migrate to Tera 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,16 +1683,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
-dependencies = [
- "memchr",
- "serde_core",
-]
-
-[[package]]
 name = "built"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1770,28 +1760,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "chrono-tz"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
-dependencies = [
- "chrono",
- "chrono-tz-build",
- "phf 0.11.3",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
-dependencies = [
- "parse-zoneinfo",
- "phf 0.11.3",
- "phf_codegen 0.11.3",
 ]
 
 [[package]]
@@ -1888,8 +1856,8 @@ dependencies = [
  "entities",
  "finl_unicode",
  "jetscii",
- "phf 0.13.1",
- "phf_codegen 0.13.1",
+ "phf",
+ "phf_codegen",
  "rustc-hash",
  "smallvec",
  "typed-arena",
@@ -2261,7 +2229,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a4d5d50b0b58df5173d8ff1192b4d1422ceae5d981b30d4b6f8ed1d673a2bc4"
 dependencies = [
- "phf 0.13.1",
+ "phf",
 ]
 
 [[package]]
@@ -2565,30 +2533,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "globset"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "globwalk"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
-dependencies = [
- "bitflags 2.13.0",
- "ignore",
- "walkdir",
-]
-
-[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2652,15 +2596,6 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "humansize"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
-dependencies = [
- "libm",
-]
 
 [[package]]
 name = "hybrid-array"
@@ -2802,22 +2737,6 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "ignore"
-version = "0.4.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
-dependencies = [
- "crossbeam-deque",
- "globset",
- "log",
- "memchr",
- "regex-automata",
- "same-file",
- "walkdir",
- "winapi-util",
 ]
 
 [[package]]
@@ -3038,12 +2957,6 @@ dependencies = [
  "arbitrary",
  "cc",
 ]
-
-[[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -3386,15 +3299,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parse-zoneinfo"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
-dependencies = [
- "regex",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3423,75 +3327,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "pest"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
-dependencies = [
- "pest",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_shared 0.11.3",
-]
-
-[[package]]
 name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_shared 0.13.1",
+ "phf_shared",
  "serde",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -3500,18 +3342,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared 0.11.3",
- "rand 0.8.6",
+ "phf_generator",
+ "phf_shared",
 ]
 
 [[package]]
@@ -3521,16 +3353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
+ "phf_shared",
 ]
 
 [[package]]
@@ -3716,33 +3539,12 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -3752,16 +3554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
+ "rand_core",
 ]
 
 [[package]]
@@ -3800,8 +3593,8 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.4",
- "rand_chacha 0.9.0",
+ "rand",
+ "rand_chacha",
  "simd_helpers",
  "thiserror",
  "v_frame",
@@ -4075,7 +3868,6 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
- "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -4313,24 +4105,12 @@ dependencies = [
 
 [[package]]
 name = "tera"
-version = "1.20.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8004bca281f2d32df3bacd59bc67b312cb4c70cea46cbd79dbe8ac5ed206722"
+checksum = "38ea62bd58771b570262e11ffa274fa9eda9986bd886e6e3a1f7f42afef8024c"
 dependencies = [
- "chrono",
- "chrono-tz",
- "globwalk",
- "humansize",
- "lazy_static",
- "percent-encoding",
- "pest",
- "pest_derive",
- "rand 0.8.6",
- "regex",
+ "indexmap",
  "serde",
- "serde_json",
- "slug",
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -4521,7 +4301,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand",
  "sha1 0.10.6",
  "thiserror",
 ]
@@ -4545,12 +4325,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4564,12 +4338,6 @@ checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0"
 hotwatch = "0.5"
-tera = {version = "1.20", features = ["preserve_order"]}
+tera = {version = "2.0", features = ["preserve_order"]}
 comrak = { version = "0.52.0", features = ["shortcodes"], default-features = false }
 walkdir = "2.5"
 chrono = { version = "0.4", features = ["serde"] }

--- a/src/embedded.rs
+++ b/src/embedded.rs
@@ -1,11 +1,11 @@
 use log::{error, info};
+use regex::Regex;
 use rust_embed::Embed;
 use std::fs;
 use std::fs::File;
 use std::io::{Error, Write};
 use std::path::Path;
 use std::sync::LazyLock;
-use tera::Tera;
 
 #[derive(Embed, Debug)]
 #[folder = "$CARGO_MANIFEST_DIR/example/static/"]
@@ -40,19 +40,59 @@ pub static EMBEDDED_SHORTCODES: LazyLock<Vec<(String, Vec<u8>)>> = LazyLock::new
     files
 });
 
-pub static EMBEDDED_TERA: LazyLock<Tera> = LazyLock::new(|| {
-    let mut tera = Tera::default();
-    tera.autoescape_on(vec![]);
-    for name in Templates::iter() {
-        let template = Templates::get(name.as_ref())
-            .expect("Failed to get embedded template - this is a build-time error");
-        let template_str = std::str::from_utf8(template.data.as_ref())
-            .expect("Embedded template contains invalid UTF-8 - this is a build-time error");
-        tera.add_raw_template(&name, template_str)
-            .expect("Failed to add embedded template to Tera - this is a build-time error");
-    }
-    tera
-});
+/// Preprocess template content for Tera 2.0 compatibility.
+/// - Strips `ignore missing` from `{% include %}` tags (not supported in Tera 2.0)
+/// - Converts dot-notation numeric indexing (`item.0`) to bracket notation (`item[0]`)
+/// - Converts positional test args to keyword args (e.g. `starting_with("x")` -> `starting_with(pat="x")`)
+pub fn strip_ignore_missing(content: &str) -> String {
+    let re = Regex::new(r#"(\{%-?\s*include\s+['"][^'"]+['"]\s+)ignore\s+missing\s*(-?%\})"#)
+        .expect("Invalid include ignore missing pattern");
+    let result = re.replace_all(content, "$1$2");
+    let dot_index = Regex::new(r"(\b[a-zA-Z_]\w*)\.(\d+)\b").expect("Invalid dot-index pattern");
+    let result = dot_index.replace_all(&result, "$1[$2]");
+    let test_positional = Regex::new(
+        r#"is (not\s+)?(starting_with|ending_with|containing|matching)\(("[^"]*"|'[^']*')\)"#,
+    )
+    .expect("Invalid test positional pattern");
+    let result = test_positional.replace_all(&result, r#"is ${1}${2}(pat=${3})"#);
+    // Convert chained property access in `is defined` / `is not defined` checks
+    // to use optional chaining: `a.b.c is defined` -> `a?.b?.c is defined`
+    let defined_check =
+        Regex::new(r"(\b[a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)+)\s+is\s+(not\s+)?defined\b")
+            .expect("Invalid defined check pattern");
+    let result = defined_check.replace_all(&result, |caps: &regex::Captures| {
+        let path = &caps[1];
+        let not_part = caps.get(2).map_or("", |m| m.as_str());
+        let parts: Vec<&str> = path.split('.').collect();
+        if parts.len() > 2 {
+            let optional_path = format!("{}?.{}", parts[0], parts[1..].join("?."));
+            format!("{optional_path} is {not_part}defined")
+        } else {
+            caps[0].to_string()
+        }
+    });
+    // Convert `{{ var.field | default(...)}}` to use optional chaining
+    // for variables that might not be defined at render time
+    let default_filter = Regex::new(r"\{\{-?\s*(\b[a-zA-Z_]\w*\.[a-zA-Z_]\w*)\s*\|\s*default\b")
+        .expect("Invalid default filter pattern");
+    default_filter
+        .replace_all(&result, |caps: &regex::Captures| {
+            let path = &caps[1];
+            let full = &caps[0];
+            let optional_path = path.replace('.', "?.");
+            full.replace(path, &optional_path)
+        })
+        .to_string()
+}
+
+/// Collect template names referenced with `ignore missing` in a template string.
+pub fn collect_ignore_missing_includes(content: &str) -> Vec<String> {
+    let re = Regex::new(r#"\{%-?\s*include\s+['"]([^'"]+)['"]\s+ignore\s+missing\s*-?%\}"#)
+        .expect("Invalid include ignore missing pattern");
+    re.captures_iter(content)
+        .map(|cap| cap[1].to_string())
+        .collect()
+}
 
 pub static EMBEDDED_AGENT_SKILLS: LazyLock<Vec<(String, Vec<u8>)>> = LazyLock::new(|| {
     let mut files: Vec<(String, Vec<u8>)> = Vec::new();

--- a/src/embedded.rs
+++ b/src/embedded.rs
@@ -44,7 +44,7 @@ pub static EMBEDDED_SHORTCODES: LazyLock<Vec<(String, Vec<u8>)>> = LazyLock::new
 /// - Strips `ignore missing` from `{% include %}` tags (not supported in Tera 2.0)
 /// - Converts dot-notation numeric indexing (`item.0`) to bracket notation (`item[0]`)
 /// - Converts positional test args to keyword args (e.g. `starting_with("x")` -> `starting_with(pat="x")`)
-pub fn strip_ignore_missing(content: &str) -> String {
+pub fn preprocess_template(content: &str) -> String {
     let re = Regex::new(r#"(\{%-?\s*include\s+['"][^'"]+['"]\s+)ignore\s+missing\s*(-?%\})"#)
         .expect("Invalid include ignore missing pattern");
     let result = re.replace_all(content, "$1$2");

--- a/src/shortcodes.rs
+++ b/src/shortcodes.rs
@@ -27,6 +27,20 @@ pub struct Shortcode {
     pub params: Vec<MacroParam>,
 }
 
+fn insert_typed(context: &mut Context, key: String, value: &str) {
+    if let Ok(n) = value.parse::<i64>() {
+        context.insert(key, &n);
+    } else if let Ok(f) = value.parse::<f64>() {
+        context.insert(key, &f);
+    } else if value == "true" {
+        context.insert(key, &true);
+    } else if value == "false" {
+        context.insert(key, &false);
+    } else {
+        context.insert(key, value);
+    }
+}
+
 pub struct ShortcodeProcessor {
     pub shortcodes: HashMap<String, Shortcode>,
     pub pattern: Regex,
@@ -354,9 +368,9 @@ impl ShortcodeProcessor {
                 .collect();
             for (param_name, param_default) in param_defs {
                 if let Some(value) = caller_params.get(&param_name) {
-                    sc_context.insert(param_name, value);
+                    insert_typed(&mut sc_context, param_name, value);
                 } else if let Some(default) = param_default {
-                    sc_context.insert(param_name, &default);
+                    insert_typed(&mut sc_context, param_name, &default);
                 }
             }
 

--- a/src/shortcodes.rs
+++ b/src/shortcodes.rs
@@ -1,4 +1,4 @@
-use crate::embedded::{strip_ignore_missing, EMBEDDED_SHORTCODES};
+use crate::embedded::{preprocess_template, EMBEDDED_SHORTCODES};
 use crate::highlight::MarmiteHighlighter;
 use crate::re;
 use log::{debug, warn};
@@ -38,7 +38,7 @@ impl ShortcodeProcessor {
         for (name, shortcode) in &self.shortcodes {
             if shortcode.is_html {
                 let component_content = Self::macro_to_component(&shortcode.content);
-                let component_content = strip_ignore_missing(&component_content);
+                let component_content = preprocess_template(&component_content);
                 tera.add_raw_template(&format!("shortcodes/{name}"), &component_content)
                     .map_err(|e| format!("Failed to add shortcode template '{name}': {e}"))?;
             }

--- a/src/shortcodes.rs
+++ b/src/shortcodes.rs
@@ -1,4 +1,4 @@
-use crate::embedded::EMBEDDED_SHORTCODES;
+use crate::embedded::{strip_ignore_missing, EMBEDDED_SHORTCODES};
 use crate::highlight::MarmiteHighlighter;
 use crate::re;
 use log::{debug, warn};
@@ -37,11 +37,40 @@ impl ShortcodeProcessor {
     pub fn add_shortcodes_to_tera(&self, tera: &mut Tera) -> Result<(), String> {
         for (name, shortcode) in &self.shortcodes {
             if shortcode.is_html {
-                tera.add_raw_template(&format!("shortcodes/{name}"), &shortcode.content)
+                let component_content = Self::macro_to_component(&shortcode.content);
+                let component_content = strip_ignore_missing(&component_content);
+                tera.add_raw_template(&format!("shortcodes/{name}"), &component_content)
                     .map_err(|e| format!("Failed to add shortcode template '{name}': {e}"))?;
             }
         }
         Ok(())
+    }
+
+    /// Convert Tera 1.x macro syntax to Tera 2.0 component syntax
+    fn macro_to_component(content: &str) -> String {
+        let mut result = content.to_string();
+        let macro_def =
+            Regex::new(r"\{%[-\s]*macro\s+(\w+)\s*\(").expect("Invalid macro def pattern");
+        for cap in macro_def.captures_iter(content) {
+            let name = &cap[1];
+            let old = cap[0].to_string();
+            let new = old
+                .replace("macro", "component")
+                .replace("-%}", "%}")
+                .replace("- %}", " %}");
+            result = result.replace(&old, &new);
+            let endmacro_re = Regex::new(&format!(r"\{{% *endmacro +{name} *%\}}"))
+                .expect("Invalid endmacro pattern");
+            result = endmacro_re
+                .replace_all(&result, "{% endcomponent %}")
+                .to_string();
+        }
+        let generic_endmacro =
+            Regex::new(r"\{%\s*endmacro\s*%\}").expect("Invalid endmacro pattern");
+        result = generic_endmacro
+            .replace_all(&result, "{% endcomponent %}")
+            .to_string();
+        result
     }
 
     /// Collect shortcodes from the `input_dir/shortcodes` directory
@@ -292,23 +321,26 @@ impl ShortcodeProcessor {
                 args.join(", ")
             };
 
-            // Render HTML shortcode using Tera macro
-            let shortcode_template = format!(
-                "{{% import \"shortcodes/{name}\" as sc -%}}\n{{{{ sc::{name}({macro_args}) }}}}"
-            );
+            // Render HTML shortcode using Tera component call
+            let component_attrs = if macro_args.is_empty() {
+                String::new()
+            } else {
+                format!(" {}", macro_args.replace(',', ""))
+            };
+            let shortcode_template = format!("{{{{ <{name}{component_attrs} /> }}}}");
 
             debug!("Rendering shortcode '{name}' with template: {shortcode_template}");
-            debug!("Shortcode params: '{params}' -> macro_args: '{macro_args}'");
+            debug!("Shortcode params: '{params}' -> component_attrs: '{component_attrs}'");
 
-            let mut tera_clone = tera.clone();
+            let tera_clone = tera.clone();
             tera_clone
-                .render_str(&shortcode_template, context)
+                .render_str(&shortcode_template, context, false)
                 .map_err(|e| format!("Failed to render shortcode '{name}': {e}"))
         } else {
             // Render markdown shortcode
-            let mut tera_clone = tera.clone();
+            let tera_clone = tera.clone();
             let rendered = tera_clone
-                .render_str(&shortcode.content, context)
+                .render_str(&shortcode.content, context, false)
                 .map_err(|e| format!("Failed to render markdown shortcode '{name}': {e}"))?;
 
             // Convert markdown to HTML

--- a/src/shortcodes.rs
+++ b/src/shortcodes.rs
@@ -9,12 +9,22 @@ use std::fs;
 use std::path::Path;
 use tera::{Context, Tera};
 
+#[derive(Debug, Clone)]
+pub struct MacroParam {
+    pub name: String,
+    pub default: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct Shortcode {
     pub name: String,
     pub content: String,
     pub is_html: bool,
     pub description: Option<String>,
+    #[serde(skip)]
+    pub body: Option<String>,
+    #[serde(skip)]
+    pub params: Vec<MacroParam>,
 }
 
 pub struct ShortcodeProcessor {
@@ -33,44 +43,41 @@ impl ShortcodeProcessor {
         }
     }
 
-    /// Add shortcodes to Tera instance
-    pub fn add_shortcodes_to_tera(&self, tera: &mut Tera) -> Result<(), String> {
-        for (name, shortcode) in &self.shortcodes {
-            if shortcode.is_html {
-                let component_content = Self::macro_to_component(&shortcode.content);
-                let component_content = preprocess_template(&component_content);
-                tera.add_raw_template(&format!("shortcodes/{name}"), &component_content)
-                    .map_err(|e| format!("Failed to add shortcode template '{name}': {e}"))?;
+    /// Extract the body and parameter list from a Tera 1.x macro definition.
+    /// Returns (body, params) where body is the template text between macro/endmacro
+    /// and params is a list of (name, optional_default) pairs.
+    fn extract_macro_body(content: &str, macro_name: &str) -> Option<(String, Vec<MacroParam>)> {
+        let header_re =
+            Regex::new(&format!(r"\{{% *macro +{macro_name}\s*\(([^)]*)\)\s*%\}}")).ok()?;
+
+        let header_match = header_re.captures(content)?;
+        let params_str = &header_match[1];
+        let header_end = header_match.get(0)?.end();
+
+        let end_re = Regex::new(&format!(r"\{{% *endmacro(?: +{macro_name})?\s*%\}}")).ok()?;
+        let end_match = end_re.find(&content[header_end..])?;
+        let body = content[header_end..header_end + end_match.start()].to_string();
+
+        let mut params = Vec::new();
+        if !params_str.trim().is_empty() {
+            for param in params_str.split(',') {
+                let param = param.trim();
+                if let Some((name, default)) = param.split_once('=') {
+                    let default = default.trim().trim_matches('"').trim_matches('\'');
+                    params.push(MacroParam {
+                        name: name.trim().to_string(),
+                        default: Some(default.to_string()),
+                    });
+                } else {
+                    params.push(MacroParam {
+                        name: param.to_string(),
+                        default: None,
+                    });
+                }
             }
         }
-        Ok(())
-    }
 
-    /// Convert Tera 1.x macro syntax to Tera 2.0 component syntax
-    fn macro_to_component(content: &str) -> String {
-        let mut result = content.to_string();
-        let macro_def =
-            Regex::new(r"\{%[-\s]*macro\s+(\w+)\s*\(").expect("Invalid macro def pattern");
-        for cap in macro_def.captures_iter(content) {
-            let name = &cap[1];
-            let old = cap[0].to_string();
-            let new = old
-                .replace("macro", "component")
-                .replace("-%}", "%}")
-                .replace("- %}", " %}");
-            result = result.replace(&old, &new);
-            let endmacro_re = Regex::new(&format!(r"\{{% *endmacro +{name} *%\}}"))
-                .expect("Invalid endmacro pattern");
-            result = endmacro_re
-                .replace_all(&result, "{% endcomponent %}")
-                .to_string();
-        }
-        let generic_endmacro =
-            Regex::new(r"\{%\s*endmacro\s*%\}").expect("Invalid endmacro pattern");
-        result = generic_endmacro
-            .replace_all(&result, "{% endcomponent %}")
-            .to_string();
-        result
+        Some((body, params))
     }
 
     /// Collect shortcodes from the `input_dir/shortcodes` directory
@@ -125,6 +132,9 @@ impl ShortcodeProcessor {
         // Extract description from Tera comment on first line
         let description = self.extract_description(&content);
 
+        let mut body = None;
+        let mut params = Vec::new();
+
         if is_html {
             // For HTML files, validate that they contain macros
             if !content.contains("{% macro") {
@@ -150,6 +160,11 @@ impl ShortcodeProcessor {
                     macro_names
                 ));
             }
+
+            if let Some((b, p)) = Self::extract_macro_body(&content, file_name) {
+                body = Some(b);
+                params = p;
+            }
         }
 
         let shortcode = Shortcode {
@@ -157,6 +172,8 @@ impl ShortcodeProcessor {
             content: content.clone(),
             is_html,
             description,
+            body,
+            params,
         };
 
         debug!("Loaded shortcode: {file_name}");
@@ -215,11 +232,22 @@ impl ShortcodeProcessor {
             // Extract description from content
             let description = self.extract_description(content);
 
+            let mut body = None;
+            let mut params = Vec::new();
+            if is_html {
+                if let Some((b, p)) = Self::extract_macro_body(content, shortcode_name) {
+                    body = Some(b);
+                    params = p;
+                }
+            }
+
             let shortcode = Shortcode {
                 name: shortcode_name.to_string(),
                 content: content.to_string(),
                 is_html,
                 description,
+                body,
+                params,
             };
 
             debug!("Loaded embedded shortcode: {shortcode_name}");
@@ -299,47 +327,48 @@ impl ShortcodeProcessor {
             .ok_or_else(|| format!("Shortcode '{name}' not found"))?;
 
         if shortcode.is_html {
-            // Parse parameters into macro arguments
-            let macro_args = if params.is_empty() {
-                String::new()
+            let body = shortcode
+                .body
+                .as_ref()
+                .ok_or_else(|| format!("Shortcode '{name}' has no extracted body"))?;
+
+            // Build context: clone caller's context, then inject shortcode parameters
+            let mut sc_context = context.clone();
+            let parsed_params = if params.is_empty() {
+                Vec::new()
             } else {
-                // Parse key=value pairs with proper quote handling
-                let mut args = Vec::new();
-                let parsed_params = Self::parse_parameters(params);
-                for (key, value) in parsed_params {
-                    // Ensure value is properly quoted for Tera
-                    let quoted_value = if value.starts_with('"') && value.ends_with('"') {
-                        value
-                    } else if value.starts_with('\'') && value.ends_with('\'') {
-                        // Convert single quotes to double quotes for Tera
-                        format!("\"{}\"", &value[1..value.len() - 1])
-                    } else {
-                        format!("\"{value}\"")
-                    };
-                    args.push(format!("{key}={quoted_value}"));
+                Self::parse_parameters(params)
+            };
+            let caller_params: HashMap<String, String> = parsed_params
+                .into_iter()
+                .map(|(k, v)| {
+                    let unquoted = v.trim_matches('"').trim_matches('\'').to_string();
+                    (k, unquoted)
+                })
+                .collect();
+
+            let param_defs: Vec<(String, Option<String>)> = shortcode
+                .params
+                .iter()
+                .map(|p| (p.name.clone(), p.default.clone()))
+                .collect();
+            for (param_name, param_default) in param_defs {
+                if let Some(value) = caller_params.get(&param_name) {
+                    sc_context.insert(param_name, value);
+                } else if let Some(default) = param_default {
+                    sc_context.insert(param_name, &default);
                 }
-                args.join(", ")
-            };
+            }
 
-            // Render HTML shortcode using Tera component call
-            let component_attrs = if macro_args.is_empty() {
-                String::new()
-            } else {
-                format!(" {}", macro_args.replace(',', ""))
-            };
-            let shortcode_template = format!("{{{{ <{name}{component_attrs} /> }}}}");
+            let preprocessed = preprocess_template(body);
 
-            debug!("Rendering shortcode '{name}' with template: {shortcode_template}");
-            debug!("Shortcode params: '{params}' -> component_attrs: '{component_attrs}'");
+            debug!("Rendering shortcode '{name}' body with context");
 
-            let tera_clone = tera.clone();
-            tera_clone
-                .render_str(&shortcode_template, context, false)
+            tera.render_str(&preprocessed, &sc_context, false)
                 .map_err(|e| format!("Failed to render shortcode '{name}': {e}"))
         } else {
             // Render markdown shortcode
-            let tera_clone = tera.clone();
-            let rendered = tera_clone
+            let rendered = tera
                 .render_str(&shortcode.content, context, false)
                 .map_err(|e| format!("Failed to render markdown shortcode '{name}': {e}"))?;
 

--- a/src/site.rs
+++ b/src/site.rs
@@ -1,7 +1,7 @@
 use crate::config::{Author, Marmite};
 use crate::content::{check_for_duplicate_slugs, Content, ContentBuilder, GroupedContent, Kind};
 use crate::embedded::{
-    collect_ignore_missing_includes, generate_static, strip_ignore_missing, Templates,
+    collect_ignore_missing_includes, generate_static, preprocess_template, Templates,
     EMBEDDED_STATIC,
 };
 use crate::gallery::Gallery;
@@ -1210,7 +1210,7 @@ fn initialize_tera(input_folder: &Path, site_data: &Data) -> (Tera, Option<Short
     // Phase 3: Load all templates in one batch with preprocessing applied
     let processed_templates: Vec<(String, String)> = all_templates
         .iter()
-        .map(|(name, content)| (name.clone(), strip_ignore_missing(content)))
+        .map(|(name, content)| (name.clone(), preprocess_template(content)))
         .collect();
     let template_refs: Vec<(&str, &str)> = processed_templates
         .iter()

--- a/src/site.rs
+++ b/src/site.rs
@@ -1226,10 +1226,6 @@ fn initialize_tera(input_folder: &Path, site_data: &Data) -> (Tera, Option<Short
         if let Err(e) = processor.collect_shortcodes(input_folder) {
             error!("Failed to collect shortcodes: {e}");
         }
-        // Add shortcodes to Tera
-        if let Err(e) = processor.add_shortcodes_to_tera(&mut tera) {
-            error!("Failed to add shortcodes to Tera: {e}");
-        }
         Some(processor)
     } else {
         None

--- a/src/site.rs
+++ b/src/site.rs
@@ -1,6 +1,9 @@
 use crate::config::{Author, Marmite};
 use crate::content::{check_for_duplicate_slugs, Content, ContentBuilder, GroupedContent, Kind};
-use crate::embedded::{generate_static, Templates, EMBEDDED_STATIC, EMBEDDED_TERA};
+use crate::embedded::{
+    collect_ignore_missing_includes, generate_static, strip_ignore_missing, Templates,
+    EMBEDDED_STATIC,
+};
 use crate::gallery::Gallery;
 use crate::highlight::{self, MarmiteHighlighter};
 use crate::image_resize;
@@ -21,10 +24,9 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
-use std::vec;
 use std::{fs, process, sync::Arc, sync::Mutex};
+use tera::Value;
 use tera::{Context, Tera};
-use tera::{Function, Value};
 use walkdir::WalkDir;
 
 #[derive(Serialize, Clone, Debug, Default)]
@@ -850,7 +852,7 @@ fn collect_global_fragments(
             crate::parser::append_references(&fragment_content, &references_path);
         let rendered_fragment = tera
             .clone()
-            .render_str(&fragment_content, global_context)
+            .render_str(&fragment_content, global_context, false)
             .unwrap_or_else(|e| {
                 error!("Failed to render fragment {fragment}: {e}");
                 fragment_content.clone()
@@ -1077,7 +1079,7 @@ fn detect_slug_collision(site_data: &Data) {
 #[allow(clippy::too_many_lines)]
 fn initialize_tera(input_folder: &Path, site_data: &Data) -> (Tera, Option<ShortcodeProcessor>) {
     let mut tera = Tera::default();
-    tera.autoescape_on(vec![]);
+    tera.autoescape_on(Vec::<&str>::new());
     tera.register_function(
         "url_for",
         UrlFor {
@@ -1136,42 +1138,18 @@ fn initialize_tera(input_folder: &Path, site_data: &Data) -> (Tera, Option<Short
     );
     tera.register_filter("remove_draft", tera_filter::RemoveDraft);
     tera.register_filter("slugify", tera_filter::Slugify);
+    tera.register_filter("striptags", tera_filter::striptags);
+    tera.register_filter("trim_start_matches", tera_filter::trim_start_matches);
+    tera.register_filter("slice", tera_filter::slice);
+    tera.register_filter("date", tera_filter::date);
 
     let templates_path = site_data.site.get_templates_path(input_folder);
     let mandatory_templates = ["base.html", "list.html", "group.html", "content.html"];
-    // Required because Tera needs base templates to be loaded before extending them
-    for template_name in &mandatory_templates {
-        let template_path = templates_path.join(template_name);
-        if template_path.exists() {
-            let template_content = fs::read_to_string(&template_path).unwrap_or_else(|e| {
-                error!("Failed to read template {template_name}: {e}");
-                String::new()
-            });
-            if let Err(e) = tera.add_raw_template(template_name, &template_content) {
-                error!("Failed to load template {template_name}: {e}");
-            }
-        } else {
-            Templates::get(template_name).map_or_else(
-                || {
-                    error!("Failed to load template: {template_name}");
-                    process::exit(1);
-                },
-                |template| {
-                    let template_str =
-                        std::str::from_utf8(template.data.as_ref()).unwrap_or_else(|e| {
-                            error!("Failed to parse template {template_name}: {e}");
-                            ""
-                        });
-                    if let Err(e) = tera.add_raw_template(template_name, template_str) {
-                        error!("Failed to load template {template_name}: {e}");
-                    }
-                },
-            );
-        }
-    }
 
-    // For every template file in the templates folder including subfolders
-    // we will load it into the tera instance one by one
+    // Phase 1: Collect all template content (user templates override embedded defaults)
+    let mut all_templates: Vec<(String, String)> = Vec::new();
+
+    // Load user templates from the templates directory
     for entry in WalkDir::new(&templates_path)
         .into_iter()
         .filter_map(Result::ok)
@@ -1184,21 +1162,62 @@ fn initialize_tera(input_folder: &Path, site_data: &Data) -> (Tera, Option<Short
             .to_str()
             .unwrap_or("")
             .to_string();
-        // windows compatibility
         let template_name = template_name.replace('\\', "/");
-        let template_name = template_name.trim_start_matches('/');
+        let template_name = template_name.trim_start_matches('/').to_string();
         let template_content = fs::read_to_string(template_path).unwrap_or_else(|e| {
             error!("Failed to read template {template_name}: {e}");
             String::new()
         });
-        if let Err(e) = tera.add_raw_template(template_name, &template_content) {
-            error!("Failed to load template {template_name}: {e}");
+        all_templates.push((template_name, template_content));
+    }
+
+    // Add embedded templates as defaults for any not provided by the user
+    let user_names: Vec<String> = all_templates.iter().map(|(n, _)| n.clone()).collect();
+    for name in Templates::iter() {
+        if user_names.iter().any(|n| n == name.as_ref()) {
+            continue;
+        }
+        if let Some(template) = Templates::get(name.as_ref()) {
+            if let Ok(template_str) = std::str::from_utf8(template.data.as_ref()) {
+                all_templates.push((name.to_string(), template_str.to_string()));
+            }
         }
     }
 
-    // Now extend the remaining templates from the embedded::Templates struct
-    if let Err(e) = tera.extend(&EMBEDDED_TERA) {
-        error!("Failed to extend with embedded templates: {e}");
+    // Verify mandatory templates exist
+    for tpl_name in &mandatory_templates {
+        if !all_templates.iter().any(|(n, _)| n == *tpl_name) {
+            error!("Failed to load template: {tpl_name}");
+            process::exit(1);
+        }
+    }
+
+    // Phase 2: Collect all optional includes and register empty templates for missing ones
+    let mut optional_includes: Vec<String> = Vec::new();
+    let all_names: Vec<&str> = all_templates.iter().map(|(n, _)| n.as_str()).collect();
+    for (_, content) in &all_templates {
+        optional_includes.extend(collect_ignore_missing_includes(content));
+    }
+    for name in &optional_includes {
+        if !all_names.contains(&name.as_str()) {
+            debug!("Registering empty template for optional include: {name}");
+            if let Err(e) = tera.add_raw_template(name, "") {
+                error!("Failed to register empty template '{name}': {e}");
+            }
+        }
+    }
+
+    // Phase 3: Load all templates in one batch with preprocessing applied
+    let processed_templates: Vec<(String, String)> = all_templates
+        .iter()
+        .map(|(name, content)| (name.clone(), strip_ignore_missing(content)))
+        .collect();
+    let template_refs: Vec<(&str, &str)> = processed_templates
+        .iter()
+        .map(|(n, c)| (n.as_str(), c.as_str()))
+        .collect();
+    if let Err(e) = tera.add_raw_templates(template_refs) {
+        error!("Failed to load templates: {e}");
     }
 
     // Initialize shortcode processor if enabled
@@ -2122,23 +2141,8 @@ fn generate_sitemap(site_data: &Data, tera: &Tera, output_path: &Path) {
 
     // Helper to generate URL using url_for
     let generate_url = |path: &str| -> String {
-        let mut args = HashMap::new();
-        args.insert("path".to_string(), Value::String(path.to_string()));
-
-        if site_data.site.url.is_empty() {
-            // Use relative URLs
-            match url_for.call(&args) {
-                Ok(Value::String(url)) => url,
-                _ => format!("/{path}"),
-            }
-        } else {
-            // Use absolute URLs
-            args.insert("abs".to_string(), Value::Bool(true));
-            match url_for.call(&args) {
-                Ok(Value::String(url)) => url,
-                _ => format!("{}/{}", site_data.site.url.trim_end_matches('/'), path),
-            }
-        }
+        let abs = !site_data.site.url.is_empty();
+        url_for.resolve(path, abs)
     };
 
     // Get all URLs from the shared collection and apply URL generation
@@ -2182,25 +2186,7 @@ fn create_urls_json(site_data: &Data) -> serde_json::Value {
     let use_abs = !site_data.site.url.is_empty();
 
     // Helper to generate URL using url_for
-    let generate_url = |path: &str| -> String {
-        let mut args = HashMap::new();
-        args.insert("path".to_string(), Value::String(path.to_string()));
-
-        if use_abs {
-            args.insert("abs".to_string(), Value::Bool(true));
-        }
-
-        match url_for.call(&args) {
-            Ok(Value::String(url)) => url,
-            _ => {
-                if use_abs {
-                    format!("{}/{}", site_data.site.url.trim_end_matches('/'), path)
-                } else {
-                    format!("/{path}")
-                }
-            }
-        }
-    };
+    let generate_url = |path: &str| -> String { url_for.resolve(path, use_abs) };
 
     // Convert URL collection to full URLs with proper formatting
     let mut output = serde_json::Map::new();
@@ -2569,11 +2555,7 @@ fn handle_list_page(
                     "next_page"
                 ]
                 .iter()
-                .map(|name| format!(
-                    "{}:{}",
-                    name,
-                    context.get(name).unwrap_or(&tera::Value::Null)
-                ))
+                .map(|name| format!("{}:{}", name, context.get(name).unwrap_or(&Value::none())))
                 .collect::<Vec<_>>()
             );
 
@@ -3011,7 +2993,7 @@ fn render_html_with_shortcodes(
     let templates = template.split(',').collect::<Vec<_>>();
     let template = templates
         .iter()
-        .find(|t| tera.get_template(t).is_ok())
+        .find(|t| tera.get_template_names().any(|n| n == **t))
         .unwrap_or(&templates[0]);
     let mut rendered = tera.render(template, context).map_err(|e| {
         error!("Error rendering template `{template}` -> {filename}: {e:#?}");

--- a/src/tera_filter.rs
+++ b/src/tera_filter.rs
@@ -1,60 +1,48 @@
 use std::str::FromStr;
 
-use tera::{to_value, Filter, Value};
+use tera::{Kwargs, State, TeraResult, Value};
 
 pub struct DefaultDateFormat {
     pub date_format: String,
 }
 
-impl Filter for DefaultDateFormat {
-    fn filter(
-        &self,
-        value: &tera::Value,
-        _: &std::collections::HashMap<String, tera::Value>,
-    ) -> tera::Result<tera::Value> {
+impl tera::Filter<&Value, TeraResult<Value>> for DefaultDateFormat {
+    fn call(&self, value: &Value, _: Kwargs, _: &State) -> TeraResult<Value> {
         let date_str = value
             .as_str()
-            .ok_or(tera::Error::msg("Missing date string"))?;
+            .ok_or(tera::Error::message("Missing date string"))?;
         let date = chrono::NaiveDateTime::from_str(date_str)
-            .map_err(|e| tera::Error::msg(e.to_string()))?;
+            .map_err(|e| tera::Error::message(e.to_string()))?;
         let formatted_date = date.format(self.date_format.as_str()).to_string();
 
-        to_value(formatted_date).map_err(tera::Error::from)
+        Ok(Value::from(formatted_date))
     }
 }
 
 pub struct Slugify;
 
-impl Filter for Slugify {
-    fn filter(
-        &self,
-        value: &Value,
-        _: &std::collections::HashMap<String, Value>,
-    ) -> tera::Result<Value> {
+impl tera::Filter<&Value, TeraResult<Value>> for Slugify {
+    fn call(&self, value: &Value, _: Kwargs, _: &State) -> TeraResult<Value> {
         let s = value
             .as_str()
-            .ok_or_else(|| tera::Error::msg("Expected a string for slugify filter"))?;
-        to_value(crate::slugify::slugify(s)).map_err(tera::Error::from)
+            .ok_or_else(|| tera::Error::message("Expected a string for slugify filter"))?;
+        Ok(Value::from(crate::slugify::slugify(s)))
     }
 }
 
 pub struct RemoveDraft;
 
-impl Filter for RemoveDraft {
-    fn filter(
-        &self,
-        value: &Value,
-        _: &std::collections::HashMap<String, Value>,
-    ) -> tera::Result<Value> {
+impl tera::Filter<&Value, TeraResult<Value>> for RemoveDraft {
+    fn call(&self, value: &Value, _: Kwargs, _: &State) -> TeraResult<Value> {
         let items = value
             .as_array()
-            .ok_or_else(|| tera::Error::msg("Expected an array"))?;
+            .ok_or_else(|| tera::Error::message("Expected an array"))?;
 
         let filtered: Vec<Value> = items
             .iter()
             .filter(|item| {
                 // Check if the item has a stream field that equals "draft"
-                if let Some(stream) = item.get("stream") {
+                if let Some(stream) = item.get_from_path("stream") {
                     if let Some(stream_str) = stream.as_str() {
                         return stream_str != "draft";
                     }
@@ -65,8 +53,59 @@ impl Filter for RemoveDraft {
             .cloned()
             .collect();
 
-        to_value(filtered).map_err(tera::Error::from)
+        Ok(Value::from_serializable(&filtered))
     }
+}
+
+/// Tera 1.x `date` filter - moved to tera-contrib in Tera 2.0
+pub fn date(val: &Value, kwargs: Kwargs, _: &State) -> TeraResult<Value> {
+    use chrono::TimeZone;
+    let format: &str = kwargs.get::<&str>("format")?.unwrap_or("%Y-%m-%d");
+    let date_str = val
+        .as_str()
+        .ok_or_else(|| tera::Error::message("date filter requires a string value"))?;
+    let parse_naive = |s: &str| -> Option<chrono::NaiveDateTime> {
+        chrono::NaiveDateTime::from_str(s).ok().or_else(|| {
+            chrono::NaiveDate::from_str(s)
+                .ok()
+                .and_then(|d| d.and_hms_opt(0, 0, 0))
+        })
+    };
+    if let Some(dt) = parse_naive(date_str) {
+        let utc = chrono::Utc.from_utc_datetime(&dt);
+        return Ok(Value::from(utc.format(format).to_string()));
+    }
+    Err(tera::Error::message(format!("Invalid date: '{date_str}'")))
+}
+
+/// Tera 1.x `striptags` filter - removed in Tera 2.0
+pub fn striptags(val: &str, _: Kwargs, _: &State) -> String {
+    let re = regex::Regex::new(r"<[^>]*>").expect("Invalid HTML tag pattern");
+    re.replace_all(val, "").to_string()
+}
+
+/// Tera 1.x `trim_start_matches` filter - renamed to `trim_start` in Tera 2.0
+pub fn trim_start_matches(val: &str, kwargs: Kwargs, _: &State) -> TeraResult<String> {
+    if let Some(pat) = kwargs.get::<&str>("pat")? {
+        Ok(val.trim_start_matches(pat).to_string())
+    } else {
+        Ok(val.trim_start().to_string())
+    }
+}
+
+/// Tera 1.x `slice` filter - removed in Tera 2.0
+pub fn slice(val: &Value, kwargs: Kwargs, _: &State) -> TeraResult<Value> {
+    let arr = val
+        .as_array()
+        .ok_or_else(|| tera::Error::message("slice filter requires an array"))?;
+    let start = kwargs.get::<i64>("start")?.unwrap_or(0).max(0) as usize;
+    let end = kwargs
+        .get::<i64>("end")?
+        .map(|e| e.max(0) as usize)
+        .unwrap_or(arr.len())
+        .min(arr.len());
+    let sliced: Vec<Value> = arr[start..end].to_vec();
+    Ok(Value::from_serializable(&sliced))
 }
 
 #[cfg(test)]

--- a/src/tera_functions.rs
+++ b/src/tera_functions.rs
@@ -1,7 +1,6 @@
 use indexmap::IndexMap;
 use serde::Serialize;
-use std::collections::HashMap;
-use tera::{to_value, Function, Result as TeraResult, Value};
+use tera::{Kwargs, State, TeraResult, Value};
 use url::Url;
 
 use crate::content::Content;
@@ -21,19 +20,13 @@ pub struct UrlFor {
     pub base_url: String,
 }
 
-impl Function for UrlFor {
-    fn call(&self, args: &HashMap<String, Value>) -> TeraResult<Value> {
-        // Extract the "path" argument
-        let mut path = args
-            .get("path")
-            .and_then(Value::as_str)
-            .ok_or_else(|| tera::Error::msg("Missing `path` argument"))?
-            .trim_start_matches("./")
-            .to_string();
+impl UrlFor {
+    pub fn resolve(&self, path: &str, abs: bool) -> String {
+        let mut path = path.trim_start_matches("./").to_string();
 
         let abs_prefixes = ["http", "https", "mailto"];
         if abs_prefixes.iter().any(|&prefix| path.starts_with(prefix)) {
-            return to_value(path).map_err(tera::Error::from);
+            return path;
         }
 
         // Ensure the path starts with "/" by adding it if necessary
@@ -57,11 +50,8 @@ impl Function for UrlFor {
                 .unwrap_or_default()
         };
 
-        // Check if the "abs" argument is provided and set to true
-        let abs = args.get("abs").and_then(Value::as_bool).unwrap_or(false);
-
         // Construct the URL based on the presence of base_url and abs flag
-        let url = if abs && !base_url.is_empty() {
+        if abs && !base_url.is_empty() {
             // Absolute URL with base_url
             format!("{}/{}", base_url, path.trim_start_matches('/'))
         } else if !base_path.is_empty() {
@@ -70,10 +60,16 @@ impl Function for UrlFor {
         } else {
             // Just the path if no base_url or base_path
             path
-        };
+        }
+    }
+}
 
-        // Return the URL as a Tera Value
-        to_value(url).map_err(tera::Error::from)
+impl tera::Function<TeraResult<Value>> for UrlFor {
+    fn call(&self, kwargs: Kwargs, _: &State) -> TeraResult<Value> {
+        let path: &str = kwargs.must_get("path")?;
+        let abs: bool = kwargs.get::<bool>("abs")?.unwrap_or(false);
+
+        Ok(Value::from(self.resolve(path, abs)))
     }
 }
 
@@ -87,23 +83,23 @@ pub struct Group {
 }
 
 #[allow(clippy::cast_possible_truncation)]
-impl Function for Group {
-    fn call(&self, args: &HashMap<String, Value>) -> TeraResult<Value> {
-        let kind = args
-            .get("kind")
-            .and_then(Value::as_str)
-            .ok_or_else(|| tera::Error::msg("Missing `kind` argument"))?;
-
-        let ord = args.get("ord").and_then(Value::as_str).unwrap_or("desc");
-
-        let items = args
-            .get("items")
-            .and_then(|v| match v {
-                Value::Number(n) => n.as_u64(),
-                Value::String(s) => s.parse::<u64>().ok(),
-                _ => None,
+impl tera::Function<TeraResult<Value>> for Group {
+    fn call(&self, kwargs: Kwargs, _: &State) -> TeraResult<Value> {
+        let kind: &str = kwargs.must_get("kind")?;
+        let ord: &str = kwargs.get::<&str>("ord")?.unwrap_or("desc");
+        let items: usize = kwargs
+            .get::<i64>("items")
+            .ok()
+            .flatten()
+            .map(|n| n as usize)
+            .or_else(|| {
+                kwargs
+                    .get::<&str>("items")
+                    .ok()
+                    .flatten()
+                    .and_then(|s| s.parse::<usize>().ok())
             })
-            .unwrap_or(0) as usize;
+            .unwrap_or(0);
 
         let grouped_content = match kind {
             "tag" => &self.site_data.tag,
@@ -111,7 +107,7 @@ impl Function for Group {
             "author" => &self.site_data.author,
             "stream" => &self.site_data.stream,
             "series" => &self.site_data.series,
-            _ => return Err(tera::Error::msg("Invalid `kind` argument")),
+            _ => return Err(tera::Error::message("Invalid `kind` argument")),
         };
 
         // Convert to vector for sorting.
@@ -167,10 +163,7 @@ impl Function for Group {
             ordered_map.insert(name, posts);
         }
 
-        let json_value = serde_json::to_value(&ordered_map)
-            .map_err(|e| tera::Error::msg(format!("Failed to convert to JSON: {e}")))?;
-
-        to_value(json_value).map_err(tera::Error::from)
+        Value::try_from_serializable(&ordered_map)
     }
 }
 
@@ -182,17 +175,15 @@ pub struct SourceLink {
     pub site_data: Data,
 }
 
-impl Function for SourceLink {
-    fn call(&self, args: &HashMap<String, Value>) -> TeraResult<Value> {
-        let content = args
-            .get("content")
-            .ok_or_else(|| tera::Error::msg("Missing `content` argument"))?;
+impl tera::Function<TeraResult<Value>> for SourceLink {
+    fn call(&self, kwargs: Kwargs, _: &State) -> TeraResult<Value> {
+        let content: &Value = kwargs.must_get("content")?;
 
         // Extract the source_path from the content
         let source_path = content
-            .get("source_path")
+            .get_from_path("source_path")
             .and_then(Value::as_str)
-            .ok_or_else(|| tera::Error::msg("Missing `source_path` in content"))?;
+            .ok_or_else(|| tera::Error::message("Missing `source_path` in content"))?;
 
         // If source_repository is configured, generate repository link
         if let Some(source_repository) = &self.site_data.site.source_repository {
@@ -203,7 +194,7 @@ impl Function for SourceLink {
                 .unwrap_or("unknown.md");
 
             let repo_url = format!("{}/{}", source_repository.trim_end_matches('/'), file_name);
-            return to_value(repo_url).map_err(tera::Error::from);
+            return Ok(Value::from(repo_url));
         }
 
         // If publish_md is true and no source_repository, generate local link
@@ -215,11 +206,11 @@ impl Function for SourceLink {
                 .unwrap_or("unknown.md");
 
             let local_url = format!("./{file_name}");
-            return to_value(local_url).map_err(tera::Error::from);
+            return Ok(Value::from(local_url));
         }
 
         // Return empty string if neither option is enabled
-        to_value("").map_err(tera::Error::from)
+        Ok(Value::from(""))
     }
 }
 
@@ -231,14 +222,8 @@ pub struct DisplayName {
     pub kind: String,
 }
 
-impl Function for DisplayName {
-    fn call(&self, args: &HashMap<String, Value>) -> TeraResult<Value> {
-        let name = args
-            .get(&self.kind)
-            .and_then(Value::as_str)
-            .ok_or_else(|| tera::Error::msg(format!("Missing `{}` argument", self.kind)))?;
-
-        // Check if there's a configured display name based on the kind
+impl DisplayName {
+    pub fn resolve(&self, name: &str) -> String {
         let display_name = match self.kind.as_str() {
             "stream" => self
                 .site_data
@@ -255,12 +240,14 @@ impl Function for DisplayName {
             _ => None,
         };
 
-        if let Some(display_name) = display_name {
-            to_value(display_name).map_err(tera::Error::from)
-        } else {
-            // Return the name itself if no display name is configured
-            to_value(name).map_err(tera::Error::from)
-        }
+        display_name.cloned().unwrap_or_else(|| name.to_string())
+    }
+}
+
+impl tera::Function<TeraResult<Value>> for DisplayName {
+    fn call(&self, kwargs: Kwargs, _: &State) -> TeraResult<Value> {
+        let name: &str = kwargs.must_get(&self.kind)?;
+        Ok(Value::from(self.resolve(name)))
     }
 }
 
@@ -271,18 +258,22 @@ pub struct GetPosts {
 }
 
 #[allow(clippy::cast_possible_truncation)]
-impl Function for GetPosts {
-    fn call(&self, args: &HashMap<String, Value>) -> TeraResult<Value> {
-        let ord = args.get("ord").and_then(Value::as_str).unwrap_or("desc");
-
-        let items = args
-            .get("items")
-            .and_then(|v| match v {
-                Value::Number(n) => n.as_u64(),
-                Value::String(s) => s.parse::<u64>().ok(),
-                _ => None,
+impl tera::Function<TeraResult<Value>> for GetPosts {
+    fn call(&self, kwargs: Kwargs, _: &State) -> TeraResult<Value> {
+        let ord: &str = kwargs.get::<&str>("ord")?.unwrap_or("desc");
+        let items: usize = kwargs
+            .get::<i64>("items")
+            .ok()
+            .flatten()
+            .map(|n| n as usize)
+            .or_else(|| {
+                kwargs
+                    .get::<&str>("items")
+                    .ok()
+                    .flatten()
+                    .and_then(|s| s.parse::<usize>().ok())
             })
-            .unwrap_or(0) as usize;
+            .unwrap_or(0);
 
         let mut posts = self.site_data.posts.clone();
 
@@ -296,7 +287,7 @@ impl Function for GetPosts {
             posts.truncate(items);
         }
 
-        to_value(posts).map_err(tera::Error::from)
+        Value::try_from_serializable(&posts)
     }
 }
 
@@ -306,36 +297,23 @@ pub struct GetDataBySlug {
     pub site_data: Data,
 }
 
-impl Function for GetDataBySlug {
+impl tera::Function<TeraResult<Value>> for GetDataBySlug {
     #[allow(clippy::too_many_lines)]
-    fn call(&self, args: &HashMap<String, Value>) -> TeraResult<Value> {
-        let slug = args
-            .get("slug")
-            .and_then(Value::as_str)
-            .ok_or_else(|| tera::Error::msg("Missing `slug` argument"))?;
+    fn call(&self, kwargs: Kwargs, _: &State) -> TeraResult<Value> {
+        let slug: &str = kwargs.must_get("slug")?;
 
         // Check what kind of content this slug refers to
         let slug_data = if slug.starts_with("series-") {
             // Series slug: series-{name}
             let series_name = slug
                 .strip_prefix("series-")
-                .ok_or_else(|| tera::Error::msg("Invalid series slug format"))?;
+                .ok_or_else(|| tera::Error::message("Invalid series slug format"))?;
             if let Some(series_contents) = self.site_data.series.map.get(series_name) {
                 let display_name_fn = DisplayName {
                     site_data: self.site_data.clone(),
                     kind: "series".to_string(),
                 };
-                let mut args = std::collections::HashMap::new();
-                args.insert(
-                    "series".to_string(),
-                    tera::Value::String(series_name.to_string()),
-                );
-                let title = display_name_fn
-                    .call(&args)
-                    .unwrap_or_else(|_| tera::Value::String(series_name.to_string()))
-                    .as_str()
-                    .unwrap_or(series_name)
-                    .to_string();
+                let title = display_name_fn.resolve(series_name);
 
                 let description = self
                     .site_data
@@ -360,30 +338,22 @@ impl Function for GetDataBySlug {
                     content_type: "series".to_string(),
                 }
             } else {
-                return Err(tera::Error::msg(format!("Series not found: {series_name}")));
+                return Err(tera::Error::message(format!(
+                    "Series not found: {series_name}"
+                )));
             }
         } else if slug.starts_with("stream-") {
             // Stream slug: stream-{name}
             // This is a special case, because streams are not prefixed with stream-
             let stream_name = slug
                 .strip_prefix("stream-")
-                .ok_or_else(|| tera::Error::msg("Invalid stream slug format"))?;
+                .ok_or_else(|| tera::Error::message("Invalid stream slug format"))?;
             if let Some(stream_contents) = self.site_data.stream.map.get(stream_name) {
                 let display_name_fn = DisplayName {
                     site_data: self.site_data.clone(),
                     kind: "stream".to_string(),
                 };
-                let mut args = std::collections::HashMap::new();
-                args.insert(
-                    "stream".to_string(),
-                    tera::Value::String(stream_name.to_string()),
-                );
-                let title = display_name_fn
-                    .call(&args)
-                    .unwrap_or_else(|_| tera::Value::String(stream_name.to_string()))
-                    .as_str()
-                    .unwrap_or(stream_name)
-                    .to_string();
+                let title = display_name_fn.resolve(stream_name);
 
                 let description = format!("{} posts", stream_contents.len());
 
@@ -401,13 +371,15 @@ impl Function for GetDataBySlug {
                     content_type: "stream".to_string(),
                 }
             } else {
-                return Err(tera::Error::msg(format!("Stream not found: {stream_name}")));
+                return Err(tera::Error::message(format!(
+                    "Stream not found: {stream_name}"
+                )));
             }
         } else if slug.starts_with("tag-") {
             // Tag slug: tag-{name}
             let tag_name = slug
                 .strip_prefix("tag-")
-                .ok_or_else(|| tera::Error::msg("Invalid tag slug format"))?;
+                .ok_or_else(|| tera::Error::message("Invalid tag slug format"))?;
             if let Some(tag_contents) = self.site_data.tag.map.get(tag_name) {
                 let image = tag_contents
                     .first()
@@ -423,13 +395,13 @@ impl Function for GetDataBySlug {
                     content_type: "tag".to_string(),
                 }
             } else {
-                return Err(tera::Error::msg(format!("Tag not found: {tag_name}")));
+                return Err(tera::Error::message(format!("Tag not found: {tag_name}")));
             }
         } else if slug.starts_with("author-") {
             // Author slug: author-{name}
             let author_name = slug
                 .strip_prefix("author-")
-                .ok_or_else(|| tera::Error::msg("Invalid author slug format"))?;
+                .ok_or_else(|| tera::Error::message("Invalid author slug format"))?;
             if let Some(author_contents) = self.site_data.author.map.get(author_name) {
                 let author_info = self.site_data.site.authors.get(author_name);
                 let title = author_info
@@ -449,13 +421,15 @@ impl Function for GetDataBySlug {
                     content_type: "author".to_string(),
                 }
             } else {
-                return Err(tera::Error::msg(format!("Author not found: {author_name}")));
+                return Err(tera::Error::message(format!(
+                    "Author not found: {author_name}"
+                )));
             }
         } else if slug.starts_with("archive-") {
             // Archive slug: archive-{year}
             let year = slug
                 .strip_prefix("archive-")
-                .ok_or_else(|| tera::Error::msg("Invalid archive slug format"))?;
+                .ok_or_else(|| tera::Error::message("Invalid archive slug format"))?;
             if let Some(archive_contents) = self.site_data.archive.map.get(year) {
                 let image = archive_contents
                     .first()
@@ -471,7 +445,9 @@ impl Function for GetDataBySlug {
                     content_type: "archive".to_string(),
                 }
             } else {
-                return Err(tera::Error::msg(format!("Archive year not found: {year}")));
+                return Err(tera::Error::message(format!(
+                    "Archive year not found: {year}"
+                )));
             }
         } else {
             // Check if it's a page
@@ -508,23 +484,13 @@ impl Function for GetDataBySlug {
                 let stream_name = slug;
                 let stream_contents =
                     self.site_data.stream.map.get(stream_name).ok_or_else(|| {
-                        tera::Error::msg(format!("Stream not found: {stream_name}"))
+                        tera::Error::message(format!("Stream not found: {stream_name}"))
                     })?;
                 let display_name_fn = DisplayName {
                     site_data: self.site_data.clone(),
                     kind: "stream".to_string(),
                 };
-                let mut args = std::collections::HashMap::new();
-                args.insert(
-                    "stream".to_string(),
-                    tera::Value::String(stream_name.to_string()),
-                );
-                let title = display_name_fn
-                    .call(&args)
-                    .unwrap_or_else(|_| tera::Value::String(stream_name.to_string()))
-                    .as_str()
-                    .unwrap_or(stream_name)
-                    .to_string();
+                let title = display_name_fn.resolve(stream_name);
                 SlugData {
                     image: stream_contents
                         .first()
@@ -537,13 +503,13 @@ impl Function for GetDataBySlug {
                     content_type: "stream".to_string(),
                 }
             } else {
-                return Err(tera::Error::msg(format!(
+                return Err(tera::Error::message(format!(
                     "Content not found for slug: {slug}"
                 )));
             }
         };
 
-        to_value(slug_data).map_err(tera::Error::from)
+        Value::try_from_serializable(&slug_data)
     }
 }
 
@@ -553,12 +519,9 @@ pub struct GetGallery {
     pub site_data: Data,
 }
 
-impl Function for GetGallery {
-    fn call(&self, args: &HashMap<String, Value>) -> TeraResult<Value> {
-        let path = args
-            .get("path")
-            .and_then(Value::as_str)
-            .ok_or_else(|| tera::Error::msg("Missing `path` argument"))?;
+impl tera::Function<TeraResult<Value>> for GetGallery {
+    fn call(&self, kwargs: Kwargs, _: &State) -> TeraResult<Value> {
+        let path: &str = kwargs.must_get("path")?;
 
         log::info!("GetGallery called with path: {path}");
         log::info!(
@@ -569,11 +532,11 @@ impl Function for GetGallery {
         // Get the gallery from site_data
         if let Some(gallery) = self.site_data.galleries.get(path) {
             log::info!("Gallery found for path: {path}");
-            to_value(gallery).map_err(tera::Error::from)
+            Ok(Value::try_from_serializable(gallery)?)
         } else {
             log::info!("Gallery not found for path: {path}");
             // Return null if gallery not found
-            Ok(Value::Null)
+            Ok(Value::none())
         }
     }
 }

--- a/src/tests/embedded.rs
+++ b/src/tests/embedded.rs
@@ -77,42 +77,42 @@ fn test_install_skills_to_claude() {
     assert!(target.join(".claude/skills/marmite/SKILL.md").exists());
 }
 
-// --- strip_ignore_missing (template preprocessing) tests ---
+// --- preprocess_template tests ---
 
 #[test]
-fn test_strip_ignore_missing_basic() {
+fn test_preprocess_template_basic() {
     let input = r#"{% include "comments.html" ignore missing %}"#;
-    let result = strip_ignore_missing(input);
+    let result = preprocess_template(input);
     assert_eq!(result, r#"{% include "comments.html" %}"#);
 }
 
 #[test]
-fn test_strip_ignore_missing_single_quotes() {
+fn test_preprocess_template_single_quotes() {
     let input = r#"{%include 'base_feeds.html' ignore missing%}"#;
-    let result = strip_ignore_missing(input);
+    let result = preprocess_template(input);
     assert_eq!(result, r#"{%include 'base_feeds.html' %}"#);
 }
 
 #[test]
-fn test_strip_ignore_missing_with_whitespace_trimming() {
+fn test_preprocess_template_with_whitespace_trimming() {
     let input = r#"{%- include "foo.html" ignore missing -%}"#;
-    let result = strip_ignore_missing(input);
+    let result = preprocess_template(input);
     assert_eq!(result, r#"{%- include "foo.html" -%}"#);
 }
 
 #[test]
-fn test_strip_ignore_missing_preserves_normal_includes() {
+fn test_preprocess_template_preserves_normal_includes() {
     let input = r#"{% include "base.html" %}"#;
-    let result = strip_ignore_missing(input);
+    let result = preprocess_template(input);
     assert_eq!(result, input);
 }
 
 #[test]
-fn test_strip_ignore_missing_multiple() {
+fn test_preprocess_template_multiple() {
     let input = r#"{% include "a.html" ignore missing %}
 {% include "b.html" %}
 {% include "c.html" ignore missing %}"#;
-    let result = strip_ignore_missing(input);
+    let result = preprocess_template(input);
     assert!(result.contains(r#"{% include "a.html" %}"#));
     assert!(result.contains(r#"{% include "b.html" %}"#));
     assert!(result.contains(r#"{% include "c.html" %}"#));
@@ -123,7 +123,7 @@ fn test_strip_ignore_missing_multiple() {
 fn test_dot_index_to_bracket() {
     let input = r#"{% set name = item.0 %}
 {% set url = item.1 %}"#;
-    let result = strip_ignore_missing(input);
+    let result = preprocess_template(input);
     assert!(result.contains("item[0]"));
     assert!(result.contains("item[1]"));
     assert!(!result.contains("item.0"));
@@ -133,28 +133,28 @@ fn test_dot_index_to_bracket() {
 #[test]
 fn test_dot_index_preserves_named_fields() {
     let input = r#"{{ content.title }}"#;
-    let result = strip_ignore_missing(input);
+    let result = preprocess_template(input);
     assert_eq!(result, input);
 }
 
 #[test]
 fn test_dot_index_nested_with_named_and_numeric() {
     let input = r#"{{ content.authors.0 }}"#;
-    let result = strip_ignore_missing(input);
+    let result = preprocess_template(input);
     assert_eq!(result, r#"{{ content.authors[0] }}"#);
 }
 
 #[test]
 fn test_starting_with_positional_to_keyword() {
     let input = r#"{% if url is starting_with("http") %}"#;
-    let result = strip_ignore_missing(input);
+    let result = preprocess_template(input);
     assert_eq!(result, r#"{% if url is starting_with(pat="http") %}"#);
 }
 
 #[test]
 fn test_not_starting_with_positional_to_keyword() {
     let input = r#"{% if content.html is not starting_with("<h1>") %}"#;
-    let result = strip_ignore_missing(input);
+    let result = preprocess_template(input);
     assert_eq!(
         result,
         r#"{% if content.html is not starting_with(pat="<h1>") %}"#
@@ -164,35 +164,35 @@ fn test_not_starting_with_positional_to_keyword() {
 #[test]
 fn test_ending_with_positional_to_keyword() {
     let input = r#"{% if name is ending_with(".html") %}"#;
-    let result = strip_ignore_missing(input);
+    let result = preprocess_template(input);
     assert_eq!(result, r#"{% if name is ending_with(pat=".html") %}"#);
 }
 
 #[test]
 fn test_containing_positional_to_keyword() {
     let input = r#"{% if text is containing("hello") %}"#;
-    let result = strip_ignore_missing(input);
+    let result = preprocess_template(input);
     assert_eq!(result, r#"{% if text is containing(pat="hello") %}"#);
 }
 
 #[test]
 fn test_starting_with_single_quotes() {
     let input = r#"{% if url is starting_with('http') %}"#;
-    let result = strip_ignore_missing(input);
+    let result = preprocess_template(input);
     assert_eq!(result, r#"{% if url is starting_with(pat='http') %}"#);
 }
 
 #[test]
 fn test_starting_with_already_keyword_unchanged() {
     let input = r#"{% if url is starting_with(pat="http") %}"#;
-    let result = strip_ignore_missing(input);
+    let result = preprocess_template(input);
     assert_eq!(result, input);
 }
 
 #[test]
 fn test_deep_defined_check_optional_chaining() {
     let input = r#"{% if site.extra.comments.source is defined %}"#;
-    let result = strip_ignore_missing(input);
+    let result = preprocess_template(input);
     assert_eq!(
         result,
         r#"{% if site?.extra?.comments?.source is defined %}"#
@@ -202,42 +202,42 @@ fn test_deep_defined_check_optional_chaining() {
 #[test]
 fn test_deep_not_defined_check_optional_chaining() {
     let input = r#"{% if site.extra.comments is not defined %}"#;
-    let result = strip_ignore_missing(input);
+    let result = preprocess_template(input);
     assert_eq!(result, r#"{% if site?.extra?.comments is not defined %}"#);
 }
 
 #[test]
 fn test_shallow_defined_check_unchanged() {
     let input = r#"{% if comments is defined %}"#;
-    let result = strip_ignore_missing(input);
+    let result = preprocess_template(input);
     assert_eq!(result, input);
 }
 
 #[test]
 fn test_two_level_defined_check_unchanged() {
     let input = r#"{% if site.url is defined %}"#;
-    let result = strip_ignore_missing(input);
+    let result = preprocess_template(input);
     assert_eq!(result, input);
 }
 
 #[test]
 fn test_default_filter_optional_chaining() {
     let input = r#"{{author.name | default(value=username)}}"#;
-    let result = strip_ignore_missing(input);
+    let result = preprocess_template(input);
     assert_eq!(result, r#"{{author?.name | default(value=username)}}"#);
 }
 
 #[test]
 fn test_default_filter_with_whitespace_trim() {
     let input = r#"{{- author.name | default(value="unknown") }}"#;
-    let result = strip_ignore_missing(input);
+    let result = preprocess_template(input);
     assert!(result.contains("author?.name"));
 }
 
 #[test]
 fn test_non_default_filter_unchanged() {
     let input = r#"{{ content.title | upper }}"#;
-    let result = strip_ignore_missing(input);
+    let result = preprocess_template(input);
     assert_eq!(result, input);
 }
 
@@ -264,7 +264,7 @@ fn test_all_transformations_combined() {
 {% if url is starting_with("http") %}
 {% if site.extra.comments.source is defined %}
 {{author.name | default(value=username)}}"#;
-    let result = strip_ignore_missing(input);
+    let result = preprocess_template(input);
     assert!(result.contains(r#"{% include "comments.html" %}"#));
     assert!(result.contains("item[0]"));
     assert!(result.contains(r#"starting_with(pat="http")"#));

--- a/src/tests/embedded.rs
+++ b/src/tests/embedded.rs
@@ -76,3 +76,198 @@ fn test_install_skills_to_claude() {
 
     assert!(target.join(".claude/skills/marmite/SKILL.md").exists());
 }
+
+// --- strip_ignore_missing (template preprocessing) tests ---
+
+#[test]
+fn test_strip_ignore_missing_basic() {
+    let input = r#"{% include "comments.html" ignore missing %}"#;
+    let result = strip_ignore_missing(input);
+    assert_eq!(result, r#"{% include "comments.html" %}"#);
+}
+
+#[test]
+fn test_strip_ignore_missing_single_quotes() {
+    let input = r#"{%include 'base_feeds.html' ignore missing%}"#;
+    let result = strip_ignore_missing(input);
+    assert_eq!(result, r#"{%include 'base_feeds.html' %}"#);
+}
+
+#[test]
+fn test_strip_ignore_missing_with_whitespace_trimming() {
+    let input = r#"{%- include "foo.html" ignore missing -%}"#;
+    let result = strip_ignore_missing(input);
+    assert_eq!(result, r#"{%- include "foo.html" -%}"#);
+}
+
+#[test]
+fn test_strip_ignore_missing_preserves_normal_includes() {
+    let input = r#"{% include "base.html" %}"#;
+    let result = strip_ignore_missing(input);
+    assert_eq!(result, input);
+}
+
+#[test]
+fn test_strip_ignore_missing_multiple() {
+    let input = r#"{% include "a.html" ignore missing %}
+{% include "b.html" %}
+{% include "c.html" ignore missing %}"#;
+    let result = strip_ignore_missing(input);
+    assert!(result.contains(r#"{% include "a.html" %}"#));
+    assert!(result.contains(r#"{% include "b.html" %}"#));
+    assert!(result.contains(r#"{% include "c.html" %}"#));
+    assert!(!result.contains("ignore missing"));
+}
+
+#[test]
+fn test_dot_index_to_bracket() {
+    let input = r#"{% set name = item.0 %}
+{% set url = item.1 %}"#;
+    let result = strip_ignore_missing(input);
+    assert!(result.contains("item[0]"));
+    assert!(result.contains("item[1]"));
+    assert!(!result.contains("item.0"));
+    assert!(!result.contains("item.1"));
+}
+
+#[test]
+fn test_dot_index_preserves_named_fields() {
+    let input = r#"{{ content.title }}"#;
+    let result = strip_ignore_missing(input);
+    assert_eq!(result, input);
+}
+
+#[test]
+fn test_dot_index_nested_with_named_and_numeric() {
+    let input = r#"{{ content.authors.0 }}"#;
+    let result = strip_ignore_missing(input);
+    assert_eq!(result, r#"{{ content.authors[0] }}"#);
+}
+
+#[test]
+fn test_starting_with_positional_to_keyword() {
+    let input = r#"{% if url is starting_with("http") %}"#;
+    let result = strip_ignore_missing(input);
+    assert_eq!(result, r#"{% if url is starting_with(pat="http") %}"#);
+}
+
+#[test]
+fn test_not_starting_with_positional_to_keyword() {
+    let input = r#"{% if content.html is not starting_with("<h1>") %}"#;
+    let result = strip_ignore_missing(input);
+    assert_eq!(
+        result,
+        r#"{% if content.html is not starting_with(pat="<h1>") %}"#
+    );
+}
+
+#[test]
+fn test_ending_with_positional_to_keyword() {
+    let input = r#"{% if name is ending_with(".html") %}"#;
+    let result = strip_ignore_missing(input);
+    assert_eq!(result, r#"{% if name is ending_with(pat=".html") %}"#);
+}
+
+#[test]
+fn test_containing_positional_to_keyword() {
+    let input = r#"{% if text is containing("hello") %}"#;
+    let result = strip_ignore_missing(input);
+    assert_eq!(result, r#"{% if text is containing(pat="hello") %}"#);
+}
+
+#[test]
+fn test_starting_with_single_quotes() {
+    let input = r#"{% if url is starting_with('http') %}"#;
+    let result = strip_ignore_missing(input);
+    assert_eq!(result, r#"{% if url is starting_with(pat='http') %}"#);
+}
+
+#[test]
+fn test_starting_with_already_keyword_unchanged() {
+    let input = r#"{% if url is starting_with(pat="http") %}"#;
+    let result = strip_ignore_missing(input);
+    assert_eq!(result, input);
+}
+
+#[test]
+fn test_deep_defined_check_optional_chaining() {
+    let input = r#"{% if site.extra.comments.source is defined %}"#;
+    let result = strip_ignore_missing(input);
+    assert_eq!(
+        result,
+        r#"{% if site?.extra?.comments?.source is defined %}"#
+    );
+}
+
+#[test]
+fn test_deep_not_defined_check_optional_chaining() {
+    let input = r#"{% if site.extra.comments is not defined %}"#;
+    let result = strip_ignore_missing(input);
+    assert_eq!(result, r#"{% if site?.extra?.comments is not defined %}"#);
+}
+
+#[test]
+fn test_shallow_defined_check_unchanged() {
+    let input = r#"{% if comments is defined %}"#;
+    let result = strip_ignore_missing(input);
+    assert_eq!(result, input);
+}
+
+#[test]
+fn test_two_level_defined_check_unchanged() {
+    let input = r#"{% if site.url is defined %}"#;
+    let result = strip_ignore_missing(input);
+    assert_eq!(result, input);
+}
+
+#[test]
+fn test_default_filter_optional_chaining() {
+    let input = r#"{{author.name | default(value=username)}}"#;
+    let result = strip_ignore_missing(input);
+    assert_eq!(result, r#"{{author?.name | default(value=username)}}"#);
+}
+
+#[test]
+fn test_default_filter_with_whitespace_trim() {
+    let input = r#"{{- author.name | default(value="unknown") }}"#;
+    let result = strip_ignore_missing(input);
+    assert!(result.contains("author?.name"));
+}
+
+#[test]
+fn test_non_default_filter_unchanged() {
+    let input = r#"{{ content.title | upper }}"#;
+    let result = strip_ignore_missing(input);
+    assert_eq!(result, input);
+}
+
+#[test]
+fn test_collect_ignore_missing_includes() {
+    let input = r#"{% include "a.html" ignore missing %}
+{% include "b.html" %}
+{%include 'c.html' ignore missing%}"#;
+    let result = collect_ignore_missing_includes(input);
+    assert_eq!(result, vec!["a.html", "c.html"]);
+}
+
+#[test]
+fn test_collect_ignore_missing_includes_none() {
+    let input = r#"{% include "a.html" %}"#;
+    let result = collect_ignore_missing_includes(input);
+    assert!(result.is_empty());
+}
+
+#[test]
+fn test_all_transformations_combined() {
+    let input = r#"{% include "comments.html" ignore missing %}
+{% set name = item.0 %}
+{% if url is starting_with("http") %}
+{% if site.extra.comments.source is defined %}
+{{author.name | default(value=username)}}"#;
+    let result = strip_ignore_missing(input);
+    assert!(result.contains(r#"{% include "comments.html" %}"#));
+    assert!(result.contains("item[0]"));
+    assert!(result.contains(r#"starting_with(pat="http")"#));
+    assert!(result.contains("site?.extra?.comments?.source is defined"));
+    assert!(result.contains("author?.name | default"));
+}

--- a/src/tests/embedded.rs
+++ b/src/tests/embedded.rs
@@ -28,9 +28,13 @@ fn test_generate_static() {
 }
 
 #[test]
-fn test_embedded_tera_initialization() {
-    let tera = &*EMBEDDED_TERA;
-    assert!(!tera.get_template_names().collect::<Vec<_>>().is_empty());
+fn test_embedded_templates_exist() {
+    let template_names: Vec<_> = Templates::iter().collect();
+    assert!(!template_names.is_empty());
+    for name in &template_names {
+        let template = Templates::get(name.as_ref());
+        assert!(template.is_some(), "Template {name} should exist");
+    }
 }
 
 #[test]

--- a/src/tests/shortcodes.rs
+++ b/src/tests/shortcodes.rs
@@ -393,3 +393,157 @@ Hello {{ name }}, welcome to {{ site_title }}!
     assert!(rendered.contains("Hello World"));
     assert!(rendered.contains("welcome to My Site"));
 }
+
+#[test]
+fn test_shortcode_renders_with_tera_functions() {
+    let mut processor = ShortcodeProcessor::new(None);
+    let shortcode_content = r#"{% macro link(path) %}
+<a href="{{ url_for(path=path) }}">{{ path }}</a>
+{% endmacro link %}"#;
+
+    processor.shortcodes.insert(
+        "link".to_string(),
+        Shortcode {
+            name: "link".to_string(),
+            content: shortcode_content.to_string(),
+            is_html: true,
+            description: None,
+            body: ShortcodeProcessor::extract_macro_body(shortcode_content, "link").map(|(b, _)| b),
+            params: ShortcodeProcessor::extract_macro_body(shortcode_content, "link")
+                .map(|(_, p)| p)
+                .unwrap_or_default(),
+        },
+    );
+
+    let mut tera = tera::Tera::default();
+    tera.register_function(
+        "url_for",
+        crate::tera_functions::UrlFor {
+            base_url: "https://example.com".to_string(),
+        },
+    );
+
+    let context = tera::Context::new();
+    let result = processor
+        .render_shortcode("link", "path=about.html", &context, &tera, None)
+        .unwrap();
+    assert!(
+        result.contains("/about.html"),
+        "Shortcode should access registered url_for function, got: {result}"
+    );
+    assert!(
+        result.contains("<a href="),
+        "Shortcode should render the link tag, got: {result}"
+    );
+}
+
+#[test]
+fn test_shortcode_applies_parameter_defaults() {
+    let mut processor = ShortcodeProcessor::new(None);
+    let shortcode_content = r#"{% macro box(title, color="blue", size="medium") %}
+<div class="{{ color }} {{ size }}">{{ title }}</div>
+{% endmacro box %}"#;
+
+    let (body, params) = ShortcodeProcessor::extract_macro_body(shortcode_content, "box").unwrap();
+    processor.shortcodes.insert(
+        "box".to_string(),
+        Shortcode {
+            name: "box".to_string(),
+            content: shortcode_content.to_string(),
+            is_html: true,
+            description: None,
+            body: Some(body),
+            params,
+        },
+    );
+
+    let tera = tera::Tera::default();
+    let context = tera::Context::new();
+
+    // Only pass title, color and size should use defaults
+    let result = processor
+        .render_shortcode("box", r#"title="Hello""#, &context, &tera, None)
+        .unwrap();
+    assert!(
+        result.contains("blue") && result.contains("medium"),
+        "Missing params should use defaults, got: {result}"
+    );
+
+    // Override one default
+    let result = processor
+        .render_shortcode("box", r#"title="Hello" color="red""#, &context, &tera, None)
+        .unwrap();
+    assert!(
+        result.contains("red") && result.contains("medium"),
+        "Caller should override defaults, got: {result}"
+    );
+}
+
+#[test]
+fn test_shortcode_accesses_context_and_params_together() {
+    let mut processor = ShortcodeProcessor::new(None);
+    let shortcode_content = r#"{% macro info(label) %}
+<span>{{ label }}: {{ site_name }}</span>
+{% endmacro info %}"#;
+
+    let (body, params) = ShortcodeProcessor::extract_macro_body(shortcode_content, "info").unwrap();
+    processor.shortcodes.insert(
+        "info".to_string(),
+        Shortcode {
+            name: "info".to_string(),
+            content: shortcode_content.to_string(),
+            is_html: true,
+            description: None,
+            body: Some(body),
+            params,
+        },
+    );
+
+    let tera = tera::Tera::default();
+    let mut context = tera::Context::new();
+    context.insert("site_name", "Marmite Blog");
+
+    let result = processor
+        .render_shortcode("info", r#"label="Site""#, &context, &tera, None)
+        .unwrap();
+    assert!(
+        result.contains("Site: Marmite Blog"),
+        "Shortcode should see both params and context vars, got: {result}"
+    );
+}
+
+#[test]
+fn test_shortcode_preprocessing_applied_to_body() {
+    let mut processor = ShortcodeProcessor::new(None);
+    // Uses starting_with with positional arg (Tera 1.x style)
+    let shortcode_content = r#"{% macro yt(id) %}
+{% if id is not starting_with("http") %}
+{% set id = "https://youtube.com/embed/" ~ id %}
+{% endif %}
+<iframe src="{{id}}"></iframe>
+{% endmacro yt %}"#;
+
+    let (body, params) = ShortcodeProcessor::extract_macro_body(shortcode_content, "yt").unwrap();
+    processor.shortcodes.insert(
+        "yt".to_string(),
+        Shortcode {
+            name: "yt".to_string(),
+            content: shortcode_content.to_string(),
+            is_html: true,
+            description: None,
+            body: Some(body),
+            params,
+        },
+    );
+
+    let tera = tera::Tera::default();
+    let context = tera::Context::new();
+
+    let result = processor
+        .render_shortcode("yt", "id=abc123", &context, &tera, None)
+        .unwrap();
+    assert!(
+        result.contains("https://youtube.com/embed/abc123"),
+        "Preprocessing should convert starting_with positional to keyword, got: {result}"
+    );
+}

--- a/src/tests/shortcodes.rs
+++ b/src/tests/shortcodes.rs
@@ -283,96 +283,113 @@ fn test_parse_parameters() {
     assert_eq!(params, vec![]);
 }
 
-// --- macro_to_component conversion tests ---
+// --- extract_macro_body tests ---
 
 #[test]
-fn test_macro_to_component_basic() {
+fn test_extract_macro_body_basic() {
     let input = r#"{% macro youtube(id, width="560") %}
 <iframe src="{{id}}" width="{{width}}"></iframe>
 {% endmacro youtube %}"#;
-    let result = ShortcodeProcessor::macro_to_component(input);
-    assert!(result.contains("{% component youtube(id, width=\"560\") %}"));
-    assert!(result.contains("{% endcomponent %}"));
-    assert!(!result.contains("macro"));
-    assert!(!result.contains("endmacro"));
+    let (body, params) = ShortcodeProcessor::extract_macro_body(input, "youtube").unwrap();
+    assert!(body.contains("<iframe"));
+    assert_eq!(params.len(), 2);
+    assert_eq!(params[0].name, "id");
+    assert!(params[0].default.is_none());
+    assert_eq!(params[1].name, "width");
+    assert_eq!(params[1].default.as_deref(), Some("560"));
 }
 
 #[test]
-fn test_macro_to_component_no_args() {
+fn test_extract_macro_body_no_args() {
     let input = r#"{% macro toc() %}
 <nav>Table of contents</nav>
 {% endmacro toc %}"#;
-    let result = ShortcodeProcessor::macro_to_component(input);
-    assert!(result.contains("{% component toc() %}"));
-    assert!(result.contains("{% endcomponent %}"));
+    let (body, params) = ShortcodeProcessor::extract_macro_body(input, "toc").unwrap();
+    assert!(body.contains("<nav>"));
+    assert!(params.is_empty());
 }
 
 #[test]
-fn test_macro_to_component_preserves_body() {
+fn test_extract_macro_body_preserves_body() {
     let input = r#"{% macro card(slug) %}
 <div class="card">{{ slug }}</div>
 {% endmacro card %}"#;
-    let result = ShortcodeProcessor::macro_to_component(input);
-    assert!(result.contains(r#"<div class="card">{{ slug }}</div>"#));
+    let (body, _) = ShortcodeProcessor::extract_macro_body(input, "card").unwrap();
+    assert!(body.contains(r#"<div class="card">{{ slug }}</div>"#));
 }
 
 #[test]
-fn test_macro_to_component_preserves_comments() {
-    let input = r#"{# Embed a YouTube video #}
-{% macro youtube(id) %}
-<iframe src="{{id}}"></iframe>
-{% endmacro youtube %}"#;
-    let result = ShortcodeProcessor::macro_to_component(input);
-    assert!(result.contains("{# Embed a YouTube video #}"));
-}
-
-#[test]
-fn test_macro_to_component_generic_endmacro() {
+fn test_extract_macro_body_generic_endmacro() {
     let input = r#"{% macro simple() %}
 <p>hello</p>
 {% endmacro %}"#;
-    let result = ShortcodeProcessor::macro_to_component(input);
-    assert!(result.contains("{% component simple() %}"));
-    assert!(result.contains("{% endcomponent %}"));
-    assert!(!result.contains("endmacro"));
+    let (body, params) = ShortcodeProcessor::extract_macro_body(input, "simple").unwrap();
+    assert!(body.contains("<p>hello</p>"));
+    assert!(params.is_empty());
 }
 
 #[test]
-fn test_macro_to_component_whitespace_trim_markers() {
-    let input = r#"{%- macro trimmed(x) -%}
-{{x}}
-{% endmacro trimmed %}"#;
-    let result = ShortcodeProcessor::macro_to_component(input);
-    assert!(result.contains("component trimmed(x)"));
-    assert!(!result.contains("macro"));
-}
-
-#[test]
-fn test_macro_to_component_multiple_defaults() {
-    let input = r#"{% macro gallery(path, ord="", width="100%", height="100%", name="", cover="") %}
+fn test_extract_macro_body_multiple_defaults() {
+    let input = r#"{% macro gallery(path, ord="", width="100%", height="100%") %}
 <div>gallery</div>
 {% endmacro gallery %}"#;
-    let result = ShortcodeProcessor::macro_to_component(input);
-    assert!(result.contains(
-        "component gallery(path, ord=\"\", width=\"100%\", height=\"100%\", name=\"\", cover=\"\")"
-    ));
-    assert!(result.contains("{% endcomponent %}"));
+    let (body, params) = ShortcodeProcessor::extract_macro_body(input, "gallery").unwrap();
+    assert!(body.contains("<div>gallery</div>"));
+    assert_eq!(params.len(), 4);
+    assert_eq!(params[0].name, "path");
+    assert!(params[0].default.is_none());
+    assert_eq!(params[1].name, "ord");
+    assert_eq!(params[1].default.as_deref(), Some(""));
+    assert_eq!(params[2].name, "width");
+    assert_eq!(params[2].default.as_deref(), Some("100%"));
+    assert_eq!(params[3].name, "height");
+    assert_eq!(params[3].default.as_deref(), Some("100%"));
 }
 
 #[test]
-fn test_macro_to_component_real_youtube_shortcode() {
+fn test_extract_macro_body_wrong_name_returns_none() {
+    let input = r#"{% macro youtube(id) %}
+<iframe></iframe>
+{% endmacro youtube %}"#;
+    assert!(ShortcodeProcessor::extract_macro_body(input, "gallery").is_none());
+}
+
+#[test]
+fn test_extract_macro_body_real_youtube() {
     let input = r#"{# Embed a YouTube video #}
 {% macro youtube(id, width="560", height="315") %}
 {% if id is not starting_with("http") %}
 {% set id = "https://www.youtube.com/embed/" ~ id %}
 {% endif %}
-<p><iframe width="{{width}}" height="{{height}}" src="{{id}}" title="" frameBorder="0" allow="accelerometer;" allowFullScreen></iframe></p>
+<p><iframe width="{{width}}" height="{{height}}" src="{{id}}"></iframe></p>
 {% endmacro youtube %}"#;
-    let result = ShortcodeProcessor::macro_to_component(input);
-    assert!(result.contains("{% component youtube(id, width=\"560\", height=\"315\") %}"));
-    assert!(result.contains("{% endcomponent %}"));
-    assert!(!result.contains("macro"));
-    assert!(!result.contains("endmacro"));
-    // Body preserved
-    assert!(result.contains("<p><iframe"));
+    let (body, params) = ShortcodeProcessor::extract_macro_body(input, "youtube").unwrap();
+    assert!(body.contains("<p><iframe"));
+    assert!(body.contains("starting_with"));
+    assert_eq!(params.len(), 3);
+    assert_eq!(params[0].name, "id");
+    assert_eq!(params[1].default.as_deref(), Some("560"));
+    assert_eq!(params[2].default.as_deref(), Some("315"));
+}
+
+// --- shortcode rendering with context access ---
+
+#[test]
+fn test_shortcode_body_can_access_context_variables() {
+    let input = r#"{% macro greet(name) %}
+Hello {{ name }}, welcome to {{ site_title }}!
+{% endmacro greet %}"#;
+
+    let (body, params) = ShortcodeProcessor::extract_macro_body(input, "greet").unwrap();
+    assert_eq!(params.len(), 1);
+    assert_eq!(params[0].name, "name");
+
+    let mut tera = tera::Tera::default();
+    let mut context = tera::Context::new();
+    context.insert("site_title", "My Site");
+    context.insert("name", "World");
+
+    let rendered = tera.render_str(&body, &context, false).unwrap();
+    assert!(rendered.contains("Hello World"));
+    assert!(rendered.contains("welcome to My Site"));
 }

--- a/src/tests/shortcodes.rs
+++ b/src/tests/shortcodes.rs
@@ -282,3 +282,97 @@ fn test_parse_parameters() {
     let params = ShortcodeProcessor::parse_parameters("   ");
     assert_eq!(params, vec![]);
 }
+
+// --- macro_to_component conversion tests ---
+
+#[test]
+fn test_macro_to_component_basic() {
+    let input = r#"{% macro youtube(id, width="560") %}
+<iframe src="{{id}}" width="{{width}}"></iframe>
+{% endmacro youtube %}"#;
+    let result = ShortcodeProcessor::macro_to_component(input);
+    assert!(result.contains("{% component youtube(id, width=\"560\") %}"));
+    assert!(result.contains("{% endcomponent %}"));
+    assert!(!result.contains("macro"));
+    assert!(!result.contains("endmacro"));
+}
+
+#[test]
+fn test_macro_to_component_no_args() {
+    let input = r#"{% macro toc() %}
+<nav>Table of contents</nav>
+{% endmacro toc %}"#;
+    let result = ShortcodeProcessor::macro_to_component(input);
+    assert!(result.contains("{% component toc() %}"));
+    assert!(result.contains("{% endcomponent %}"));
+}
+
+#[test]
+fn test_macro_to_component_preserves_body() {
+    let input = r#"{% macro card(slug) %}
+<div class="card">{{ slug }}</div>
+{% endmacro card %}"#;
+    let result = ShortcodeProcessor::macro_to_component(input);
+    assert!(result.contains(r#"<div class="card">{{ slug }}</div>"#));
+}
+
+#[test]
+fn test_macro_to_component_preserves_comments() {
+    let input = r#"{# Embed a YouTube video #}
+{% macro youtube(id) %}
+<iframe src="{{id}}"></iframe>
+{% endmacro youtube %}"#;
+    let result = ShortcodeProcessor::macro_to_component(input);
+    assert!(result.contains("{# Embed a YouTube video #}"));
+}
+
+#[test]
+fn test_macro_to_component_generic_endmacro() {
+    let input = r#"{% macro simple() %}
+<p>hello</p>
+{% endmacro %}"#;
+    let result = ShortcodeProcessor::macro_to_component(input);
+    assert!(result.contains("{% component simple() %}"));
+    assert!(result.contains("{% endcomponent %}"));
+    assert!(!result.contains("endmacro"));
+}
+
+#[test]
+fn test_macro_to_component_whitespace_trim_markers() {
+    let input = r#"{%- macro trimmed(x) -%}
+{{x}}
+{% endmacro trimmed %}"#;
+    let result = ShortcodeProcessor::macro_to_component(input);
+    assert!(result.contains("component trimmed(x)"));
+    assert!(!result.contains("macro"));
+}
+
+#[test]
+fn test_macro_to_component_multiple_defaults() {
+    let input = r#"{% macro gallery(path, ord="", width="100%", height="100%", name="", cover="") %}
+<div>gallery</div>
+{% endmacro gallery %}"#;
+    let result = ShortcodeProcessor::macro_to_component(input);
+    assert!(result.contains(
+        "component gallery(path, ord=\"\", width=\"100%\", height=\"100%\", name=\"\", cover=\"\")"
+    ));
+    assert!(result.contains("{% endcomponent %}"));
+}
+
+#[test]
+fn test_macro_to_component_real_youtube_shortcode() {
+    let input = r#"{# Embed a YouTube video #}
+{% macro youtube(id, width="560", height="315") %}
+{% if id is not starting_with("http") %}
+{% set id = "https://www.youtube.com/embed/" ~ id %}
+{% endif %}
+<p><iframe width="{{width}}" height="{{height}}" src="{{id}}" title="" frameBorder="0" allow="accelerometer;" allowFullScreen></iframe></p>
+{% endmacro youtube %}"#;
+    let result = ShortcodeProcessor::macro_to_component(input);
+    assert!(result.contains("{% component youtube(id, width=\"560\", height=\"315\") %}"));
+    assert!(result.contains("{% endcomponent %}"));
+    assert!(!result.contains("macro"));
+    assert!(!result.contains("endmacro"));
+    // Body preserved
+    assert!(result.contains("<p><iframe"));
+}

--- a/src/tests/tera_filter.rs
+++ b/src/tests/tera_filter.rs
@@ -1,18 +1,19 @@
 use super::*;
 use serde_json::json;
-use std::collections::HashMap;
-use tera::Value;
 
 #[test]
 fn test_default_date_format_valid_date() {
     let filter = DefaultDateFormat {
         date_format: "%Y-%m-%d".to_string(),
     };
-    let value = Value::String("2023-12-25T10:30:00".to_string());
-    let args = HashMap::new();
-
-    let result = filter.filter(&value, &args).unwrap();
-    assert_eq!(result, Value::String("2023-12-25".to_string()));
+    let mut tera = tera::Tera::default();
+    tera.register_filter("default_date_format", filter);
+    tera.add_raw_template("test", r#"{{ val | default_date_format }}"#)
+        .unwrap();
+    let mut ctx = tera::Context::new();
+    ctx.insert("val", "2023-12-25T10:30:00");
+    let result = tera.render("test", &ctx).unwrap();
+    assert_eq!(result, "2023-12-25");
 }
 
 #[test]
@@ -20,10 +21,13 @@ fn test_default_date_format_invalid_date_string() {
     let filter = DefaultDateFormat {
         date_format: "%Y-%m-%d".to_string(),
     };
-    let value = Value::String("invalid-date".to_string());
-    let args = HashMap::new();
-
-    let result = filter.filter(&value, &args);
+    let mut tera = tera::Tera::default();
+    tera.register_filter("default_date_format", filter);
+    tera.add_raw_template("test", r#"{{ val | default_date_format }}"#)
+        .unwrap();
+    let mut ctx = tera::Context::new();
+    ctx.insert("val", "invalid-date");
+    let result = tera.render("test", &ctx);
     assert!(result.is_err());
 }
 
@@ -32,64 +36,82 @@ fn test_default_date_format_non_string_value() {
     let filter = DefaultDateFormat {
         date_format: "%Y-%m-%d".to_string(),
     };
-    let value = Value::Number(123.into());
-    let args = HashMap::new();
-
-    let result = filter.filter(&value, &args);
+    let mut tera = tera::Tera::default();
+    tera.register_filter("default_date_format", filter);
+    tera.add_raw_template("test", r#"{{ val | default_date_format }}"#)
+        .unwrap();
+    let mut ctx = tera::Context::new();
+    ctx.insert("val", &123);
+    let result = tera.render("test", &ctx);
     assert!(result.is_err());
 }
 
 #[test]
 fn test_remove_draft_filter_items() {
     let filter = RemoveDraft;
+    let mut tera = tera::Tera::default();
+    tera.register_filter("remove_draft", filter);
+    tera.add_raw_template("test", r#"{{ items | remove_draft | length }}"#)
+        .unwrap();
+
     let items = json!([
         {"title": "Published Post", "stream": "main"},
         {"title": "Draft Post", "stream": "draft"},
         {"title": "Another Post", "stream": "blog"}
     ]);
-    let args = HashMap::new();
+    let mut ctx = tera::Context::new();
+    ctx.insert("items", &items);
 
-    let result = filter.filter(&items, &args).unwrap();
-    let filtered_array = result.as_array().unwrap();
-
-    assert_eq!(filtered_array.len(), 2);
-    assert_eq!(filtered_array[0]["title"], "Published Post");
-    assert_eq!(filtered_array[1]["title"], "Another Post");
+    let result = tera.render("test", &ctx).unwrap();
+    assert_eq!(result.trim(), "2");
 }
 
 #[test]
 fn test_remove_draft_filter_no_stream_field() {
     let filter = RemoveDraft;
+    let mut tera = tera::Tera::default();
+    tera.register_filter("remove_draft", filter);
+    tera.add_raw_template("test", r#"{{ items | remove_draft | length }}"#)
+        .unwrap();
+
     let items = json!([
         {"title": "Post Without Stream"},
         {"title": "Another Post", "stream": "main"}
     ]);
-    let args = HashMap::new();
+    let mut ctx = tera::Context::new();
+    ctx.insert("items", &items);
 
-    let result = filter.filter(&items, &args).unwrap();
-    let filtered_array = result.as_array().unwrap();
-
-    assert_eq!(filtered_array.len(), 2);
+    let result = tera.render("test", &ctx).unwrap();
+    assert_eq!(result.trim(), "2");
 }
 
 #[test]
 fn test_remove_draft_filter_non_array_value() {
     let filter = RemoveDraft;
-    let value = Value::String("not an array".to_string());
-    let args = HashMap::new();
+    let mut tera = tera::Tera::default();
+    tera.register_filter("remove_draft", filter);
+    tera.add_raw_template("test", r#"{{ items | remove_draft }}"#)
+        .unwrap();
 
-    let result = filter.filter(&value, &args);
+    let mut ctx = tera::Context::new();
+    ctx.insert("items", "not an array");
+
+    let result = tera.render("test", &ctx);
     assert!(result.is_err());
 }
 
 #[test]
 fn test_remove_draft_filter_empty_array() {
     let filter = RemoveDraft;
-    let items = json!([]);
-    let args = HashMap::new();
+    let mut tera = tera::Tera::default();
+    tera.register_filter("remove_draft", filter);
+    tera.add_raw_template("test", r#"{{ items | remove_draft | length }}"#)
+        .unwrap();
 
-    let result = filter.filter(&items, &args).unwrap();
-    let filtered_array = result.as_array().unwrap();
+    let items: Vec<serde_json::Value> = vec![];
+    let mut ctx = tera::Context::new();
+    ctx.insert("items", &items);
 
-    assert_eq!(filtered_array.len(), 0);
+    let result = tera.render("test", &ctx).unwrap();
+    assert_eq!(result.trim(), "0");
 }

--- a/src/tests/tera_filter.rs
+++ b/src/tests/tera_filter.rs
@@ -115,3 +115,204 @@ fn test_remove_draft_filter_empty_array() {
     let result = tera.render("test", &ctx).unwrap();
     assert_eq!(result.trim(), "0");
 }
+
+// --- Tera 2.0 compatibility filter shim tests ---
+
+#[test]
+fn test_date_filter_datetime_format() {
+    let mut tera = tera::Tera::default();
+    tera.register_filter("date", date);
+    tera.add_raw_template("test", r#"{{ val | date(format="%Y-%m-%d") }}"#)
+        .unwrap();
+    let mut ctx = tera::Context::new();
+    ctx.insert("val", "2024-06-15T14:30:00");
+    let result = tera.render("test", &ctx).unwrap();
+    assert_eq!(result, "2024-06-15");
+}
+
+#[test]
+fn test_date_filter_date_only() {
+    let mut tera = tera::Tera::default();
+    tera.register_filter("date", date);
+    tera.add_raw_template("test", r#"{{ val | date(format="%Y-%m-%d") }}"#)
+        .unwrap();
+    let mut ctx = tera::Context::new();
+    ctx.insert("val", "2024-06-15");
+    let result = tera.render("test", &ctx).unwrap();
+    assert_eq!(result, "2024-06-15");
+}
+
+#[test]
+fn test_date_filter_rfc3339() {
+    let mut tera = tera::Tera::default();
+    tera.register_filter("date", date);
+    tera.add_raw_template("test", r#"{{ val | date(format="%+") }}"#)
+        .unwrap();
+    let mut ctx = tera::Context::new();
+    ctx.insert("val", "2024-06-15T14:30:00");
+    let result = tera.render("test", &ctx).unwrap();
+    assert!(result.contains("2024-06-15"));
+}
+
+#[test]
+fn test_date_filter_default_format() {
+    let mut tera = tera::Tera::default();
+    tera.register_filter("date", date);
+    tera.add_raw_template("test", r#"{{ val | date }}"#)
+        .unwrap();
+    let mut ctx = tera::Context::new();
+    ctx.insert("val", "2024-06-15T14:30:00");
+    let result = tera.render("test", &ctx).unwrap();
+    assert_eq!(result, "2024-06-15");
+}
+
+#[test]
+fn test_date_filter_invalid_date() {
+    let mut tera = tera::Tera::default();
+    tera.register_filter("date", date);
+    tera.add_raw_template("test", r#"{{ val | date }}"#)
+        .unwrap();
+    let mut ctx = tera::Context::new();
+    ctx.insert("val", "not-a-date");
+    let result = tera.render("test", &ctx);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_striptags_filter() {
+    let mut tera = tera::Tera::default();
+    tera.register_filter("striptags", striptags);
+    tera.add_raw_template("test", r#"{{ val | striptags }}"#)
+        .unwrap();
+    let mut ctx = tera::Context::new();
+    ctx.insert("val", "<p>Hello <strong>world</strong></p>");
+    let result = tera.render("test", &ctx).unwrap();
+    assert_eq!(result, "Hello world");
+}
+
+#[test]
+fn test_striptags_filter_no_tags() {
+    let mut tera = tera::Tera::default();
+    tera.register_filter("striptags", striptags);
+    tera.add_raw_template("test", r#"{{ val | striptags }}"#)
+        .unwrap();
+    let mut ctx = tera::Context::new();
+    ctx.insert("val", "plain text");
+    let result = tera.render("test", &ctx).unwrap();
+    assert_eq!(result, "plain text");
+}
+
+#[test]
+fn test_striptags_filter_nested() {
+    let mut tera = tera::Tera::default();
+    tera.register_filter("striptags", striptags);
+    tera.add_raw_template("test", r#"{{ val | striptags }}"#)
+        .unwrap();
+    let mut ctx = tera::Context::new();
+    ctx.insert(
+        "val",
+        r#"<div class="wrapper"><h1>Title</h1><p>Body</p></div>"#,
+    );
+    let result = tera.render("test", &ctx).unwrap();
+    assert_eq!(result, "TitleBody");
+}
+
+#[test]
+fn test_trim_start_matches_filter_with_pattern() {
+    let mut tera = tera::Tera::default();
+    tera.register_filter("trim_start_matches", trim_start_matches);
+    tera.add_raw_template("test", r#"{{ val | trim_start_matches(pat="Hello ") }}"#)
+        .unwrap();
+    let mut ctx = tera::Context::new();
+    ctx.insert("val", "Hello World");
+    let result = tera.render("test", &ctx).unwrap();
+    assert_eq!(result, "World");
+}
+
+#[test]
+fn test_trim_start_matches_filter_no_match() {
+    let mut tera = tera::Tera::default();
+    tera.register_filter("trim_start_matches", trim_start_matches);
+    tera.add_raw_template("test", r#"{{ val | trim_start_matches(pat="xyz") }}"#)
+        .unwrap();
+    let mut ctx = tera::Context::new();
+    ctx.insert("val", "Hello World");
+    let result = tera.render("test", &ctx).unwrap();
+    assert_eq!(result, "Hello World");
+}
+
+#[test]
+fn test_trim_start_matches_filter_no_pattern() {
+    let mut tera = tera::Tera::default();
+    tera.register_filter("trim_start_matches", trim_start_matches);
+    tera.add_raw_template("test", r#"{{ val | trim_start_matches }}"#)
+        .unwrap();
+    let mut ctx = tera::Context::new();
+    ctx.insert("val", "   spaces");
+    let result = tera.render("test", &ctx).unwrap();
+    assert_eq!(result, "spaces");
+}
+
+#[test]
+fn test_slice_filter_with_end() {
+    let mut tera = tera::Tera::default();
+    tera.register_filter("slice", slice);
+    tera.add_raw_template("test", r#"{{ items | slice(end=2) | length }}"#)
+        .unwrap();
+    let items = vec!["a", "b", "c", "d"];
+    let mut ctx = tera::Context::new();
+    ctx.insert("items", &items);
+    let result = tera.render("test", &ctx).unwrap();
+    assert_eq!(result.trim(), "2");
+}
+
+#[test]
+fn test_slice_filter_with_start_and_end() {
+    let mut tera = tera::Tera::default();
+    tera.register_filter("slice", slice);
+    tera.add_raw_template("test", r#"{{ items | slice(start=1, end=3) | length }}"#)
+        .unwrap();
+    let items = vec!["a", "b", "c", "d", "e"];
+    let mut ctx = tera::Context::new();
+    ctx.insert("items", &items);
+    let result = tera.render("test", &ctx).unwrap();
+    assert_eq!(result.trim(), "2");
+}
+
+#[test]
+fn test_slice_filter_end_beyond_length() {
+    let mut tera = tera::Tera::default();
+    tera.register_filter("slice", slice);
+    tera.add_raw_template("test", r#"{{ items | slice(end=100) | length }}"#)
+        .unwrap();
+    let items = vec!["a", "b"];
+    let mut ctx = tera::Context::new();
+    ctx.insert("items", &items);
+    let result = tera.render("test", &ctx).unwrap();
+    assert_eq!(result.trim(), "2");
+}
+
+#[test]
+fn test_slice_filter_empty_array() {
+    let mut tera = tera::Tera::default();
+    tera.register_filter("slice", slice);
+    tera.add_raw_template("test", r#"{{ items | slice(end=3) | length }}"#)
+        .unwrap();
+    let items: Vec<&str> = vec![];
+    let mut ctx = tera::Context::new();
+    ctx.insert("items", &items);
+    let result = tera.render("test", &ctx).unwrap();
+    assert_eq!(result.trim(), "0");
+}
+
+#[test]
+fn test_slice_filter_non_array_error() {
+    let mut tera = tera::Tera::default();
+    tera.register_filter("slice", slice);
+    tera.add_raw_template("test", r#"{{ val | slice(end=2) }}"#)
+        .unwrap();
+    let mut ctx = tera::Context::new();
+    ctx.insert("val", "not an array");
+    let result = tera.render("test", &ctx);
+    assert!(result.is_err());
+}

--- a/src/tests/tera_functions.rs
+++ b/src/tests/tera_functions.rs
@@ -1,18 +1,13 @@
 use super::*;
 use serde_json::json;
-use std::collections::HashMap;
-use tera::Value;
 
 #[test]
 fn test_url_for_basic_path() {
     let url_for = UrlFor {
         base_url: String::new(),
     };
-    let mut args = HashMap::new();
-    args.insert("path".to_string(), Value::String("about.html".to_string()));
-
-    let result = url_for.call(&args).unwrap();
-    assert_eq!(result, Value::String("/about.html".to_string()));
+    let result = url_for.resolve("about.html", false);
+    assert_eq!(result, "/about.html");
 }
 
 #[test]
@@ -20,15 +15,8 @@ fn test_url_for_absolute_path() {
     let url_for = UrlFor {
         base_url: "https://example.com".to_string(),
     };
-    let mut args = HashMap::new();
-    args.insert("path".to_string(), Value::String("about.html".to_string()));
-    args.insert("abs".to_string(), Value::Bool(true));
-
-    let result = url_for.call(&args).unwrap();
-    assert_eq!(
-        result,
-        Value::String("https://example.com/about.html".to_string())
-    );
+    let result = url_for.resolve("about.html", true);
+    assert_eq!(result, "https://example.com/about.html");
 }
 
 #[test]
@@ -36,24 +24,21 @@ fn test_url_for_external_url() {
     let url_for = UrlFor {
         base_url: String::new(),
     };
-    let mut args = HashMap::new();
-    args.insert(
-        "path".to_string(),
-        Value::String("https://external.com".to_string()),
-    );
-
-    let result = url_for.call(&args).unwrap();
-    assert_eq!(result, Value::String("https://external.com".to_string()));
+    let result = url_for.resolve("https://external.com", false);
+    assert_eq!(result, "https://external.com");
 }
 
 #[test]
 fn test_url_for_missing_path() {
-    let url_for = UrlFor {
-        base_url: String::new(),
-    };
-    let args = HashMap::new();
-
-    let result = url_for.call(&args);
+    let mut tera = tera::Tera::default();
+    tera.register_function(
+        "url_for",
+        UrlFor {
+            base_url: String::new(),
+        },
+    );
+    tera.add_raw_template("test", r#"{{ url_for() }}"#).unwrap();
+    let result = tera.render("test", &tera::Context::new());
     assert!(result.is_err());
 }
 
@@ -69,47 +54,49 @@ fn create_test_data() -> Data {
 #[test]
 fn test_group_function_tag() {
     let site_data = create_test_data();
-    let group = Group { site_data };
-    let mut args = HashMap::new();
-    args.insert("kind".to_string(), Value::String("tag".to_string()));
-
-    let result = group.call(&args);
+    let mut tera = tera::Tera::default();
+    tera.register_function("group", Group { site_data });
+    tera.add_raw_template("test", r#"{{ group(kind="tag") }}"#)
+        .unwrap();
+    let result = tera.render("test", &tera::Context::new());
     assert!(result.is_ok());
 }
 
 #[test]
 fn test_group_function_invalid_kind() {
     let site_data = create_test_data();
-    let group = Group { site_data };
-    let mut args = HashMap::new();
-    args.insert("kind".to_string(), Value::String("invalid".to_string()));
-
-    let result = group.call(&args);
+    let mut tera = tera::Tera::default();
+    tera.register_function("group", Group { site_data });
+    tera.add_raw_template("test", r#"{{ group(kind="invalid") }}"#)
+        .unwrap();
+    let result = tera.render("test", &tera::Context::new());
     assert!(result.is_err());
 }
 
 #[test]
 fn test_group_function_missing_kind() {
     let site_data = create_test_data();
-    let group = Group { site_data };
-    let args = HashMap::new();
-
-    let result = group.call(&args);
+    let mut tera = tera::Tera::default();
+    tera.register_function("group", Group { site_data });
+    tera.add_raw_template("test", r#"{{ group() }}"#).unwrap();
+    let result = tera.render("test", &tera::Context::new());
     assert!(result.is_err());
 }
 
 #[test]
 fn test_source_link_empty() {
     let site_data = create_test_data();
-    let source_link = SourceLink { site_data };
-    let mut args = HashMap::new();
+    let mut tera = tera::Tera::default();
+    tera.register_function("source_link", SourceLink { site_data });
+    tera.add_raw_template("test", r#"{{ source_link(content=content) }}"#)
+        .unwrap();
     let content = json!({
         "source_path": "/path/to/file.md"
     });
-    args.insert("content".to_string(), content);
-
-    let result = source_link.call(&args).unwrap();
-    assert_eq!(result, Value::String(String::new()));
+    let mut ctx = tera::Context::new();
+    ctx.insert("content", &content);
+    let result = tera.render("test", &ctx).unwrap();
+    assert_eq!(result, "");
 }
 
 #[test]
@@ -119,122 +106,106 @@ fn test_display_name_stream_without_config() {
         site_data,
         kind: "stream".to_string(),
     };
-    let mut args = HashMap::new();
-    args.insert("stream".to_string(), Value::String("main".to_string()));
-
-    let result = display_name.call(&args).unwrap();
-    assert_eq!(result, Value::String("main".to_string()));
+    let result = display_name.resolve("main");
+    assert_eq!(result, "main");
 }
 
 #[test]
 fn test_get_posts_default() {
     let site_data = create_test_data();
-    let get_posts = GetPosts { site_data };
-    let args = HashMap::new();
-
-    let result = get_posts.call(&args);
+    let mut tera = tera::Tera::default();
+    tera.register_function("get_posts", GetPosts { site_data });
+    tera.add_raw_template("test", r#"{{ get_posts() }}"#)
+        .unwrap();
+    let result = tera.render("test", &tera::Context::new());
     assert!(result.is_ok());
-
-    // Should return all posts in default desc order
-    let posts = result.unwrap();
-    assert!(posts.is_array());
 }
 
 #[test]
 fn test_get_posts_with_limit() {
     let site_data = create_test_data();
-    let get_posts = GetPosts { site_data };
-    let mut args = HashMap::new();
-    args.insert("items".to_string(), Value::Number(2.into()));
-
-    let result = get_posts.call(&args);
+    let mut tera = tera::Tera::default();
+    tera.register_function("get_posts", GetPosts { site_data });
+    tera.add_raw_template("test", r#"{{ get_posts(items=2) }}"#)
+        .unwrap();
+    let result = tera.render("test", &tera::Context::new());
     assert!(result.is_ok());
 }
 
 #[test]
 fn test_get_posts_asc_order() {
     let site_data = create_test_data();
-    let get_posts = GetPosts { site_data };
-    let mut args = HashMap::new();
-    args.insert("ord".to_string(), Value::String("asc".to_string()));
-
-    let result = get_posts.call(&args);
+    let mut tera = tera::Tera::default();
+    tera.register_function("get_posts", GetPosts { site_data });
+    tera.add_raw_template("test", r#"{{ get_posts(ord="asc") }}"#)
+        .unwrap();
+    let result = tera.render("test", &tera::Context::new());
     assert!(result.is_ok());
 }
 
 #[test]
 fn test_get_posts_with_string_limit() {
     let site_data = create_test_data();
-    let get_posts = GetPosts { site_data };
-    let mut args = HashMap::new();
-    args.insert("items".to_string(), Value::String("5".to_string()));
-
-    let result = get_posts.call(&args);
+    let mut tera = tera::Tera::default();
+    tera.register_function("get_posts", GetPosts { site_data });
+    tera.add_raw_template("test", r#"{{ get_posts(items="5") }}"#)
+        .unwrap();
+    let result = tera.render("test", &tera::Context::new());
     assert!(result.is_ok());
 }
 
 #[test]
 fn test_group_function_tags_with_params() {
     let site_data = create_test_data();
-    let group = Group { site_data };
-    let mut args = HashMap::new();
-    args.insert("kind".to_string(), Value::String("tag".to_string()));
-    args.insert("ord".to_string(), Value::String("asc".to_string()));
-    args.insert("items".to_string(), Value::Number(2.into()));
-
-    let result = group.call(&args);
+    let mut tera = tera::Tera::default();
+    tera.register_function("group", Group { site_data });
+    tera.add_raw_template("test", r#"{{ group(kind="tag", ord="asc", items=2) }}"#)
+        .unwrap();
+    let result = tera.render("test", &tera::Context::new());
     assert!(result.is_ok());
 }
 
 #[test]
 fn test_group_function_series_with_params() {
     let site_data = create_test_data();
-    let group = Group { site_data };
-    let mut args = HashMap::new();
-    args.insert("kind".to_string(), Value::String("series".to_string()));
-    args.insert("ord".to_string(), Value::String("desc".to_string()));
-
-    let result = group.call(&args);
+    let mut tera = tera::Tera::default();
+    tera.register_function("group", Group { site_data });
+    tera.add_raw_template("test", r#"{{ group(kind="series", ord="desc") }}"#)
+        .unwrap();
+    let result = tera.render("test", &tera::Context::new());
     assert!(result.is_ok());
 }
 
 #[test]
 fn test_group_function_streams_with_params() {
     let site_data = create_test_data();
-    let group = Group { site_data };
-    let mut args = HashMap::new();
-    args.insert("kind".to_string(), Value::String("stream".to_string()));
-    args.insert("items".to_string(), Value::String("5".to_string()));
-
-    let result = group.call(&args);
+    let mut tera = tera::Tera::default();
+    tera.register_function("group", Group { site_data });
+    tera.add_raw_template("test", r#"{{ group(kind="stream", items="5") }}"#)
+        .unwrap();
+    let result = tera.render("test", &tera::Context::new());
     assert!(result.is_ok());
 }
 
 #[test]
 fn test_get_data_by_slug_missing_slug() {
     let site_data = create_test_data();
-    let get_data_by_slug = GetDataBySlug { site_data };
-    let args = HashMap::new();
-
-    let result = get_data_by_slug.call(&args);
+    let mut tera = tera::Tera::default();
+    tera.register_function("get_data_by_slug", GetDataBySlug { site_data });
+    tera.add_raw_template("test", r#"{{ get_data_by_slug() }}"#)
+        .unwrap();
+    let result = tera.render("test", &tera::Context::new());
     assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("Missing `slug` argument"));
 }
 
 #[test]
 fn test_get_data_by_slug_nonexistent_slug() {
     let site_data = create_test_data();
-    let get_data_by_slug = GetDataBySlug { site_data };
-    let mut args = HashMap::new();
-    args.insert(
-        "slug".to_string(),
-        Value::String("nonexistent-slug".to_string()),
-    );
-
-    let result = get_data_by_slug.call(&args);
+    let mut tera = tera::Tera::default();
+    tera.register_function("get_data_by_slug", GetDataBySlug { site_data });
+    tera.add_raw_template("test", r#"{{ get_data_by_slug(slug="nonexistent-slug") }}"#)
+        .unwrap();
+    let result = tera.render("test", &tera::Context::new());
     assert!(result.is_err());
     assert!(result
         .unwrap_err()
@@ -245,14 +216,11 @@ fn test_get_data_by_slug_nonexistent_slug() {
 #[test]
 fn test_get_data_by_slug_tag_not_found() {
     let site_data = create_test_data();
-    let get_data_by_slug = GetDataBySlug { site_data };
-    let mut args = HashMap::new();
-    args.insert(
-        "slug".to_string(),
-        Value::String("tag-nonexistent".to_string()),
-    );
-
-    let result = get_data_by_slug.call(&args);
+    let mut tera = tera::Tera::default();
+    tera.register_function("get_data_by_slug", GetDataBySlug { site_data });
+    tera.add_raw_template("test", r#"{{ get_data_by_slug(slug="tag-nonexistent") }}"#)
+        .unwrap();
+    let result = tera.render("test", &tera::Context::new());
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("Tag not found"));
 }

--- a/tests/example_site.rs
+++ b/tests/example_site.rs
@@ -1,0 +1,322 @@
+use std::fs;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn build_example_site() -> (TempDir, std::process::Output) {
+    let temp_dir = TempDir::new().unwrap();
+    let output_dir = temp_dir.path().join("output");
+
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--",
+            "example",
+            output_dir.to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute marmite");
+
+    (temp_dir, output)
+}
+
+#[test]
+fn test_example_site_builds_without_errors() {
+    let (temp_dir, output) = build_example_site();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "Example site build failed: {stderr}"
+    );
+
+    let error_lines: Vec<&str> = stderr.lines().filter(|l| l.contains("ERROR")).collect();
+    assert!(
+        error_lines.is_empty(),
+        "Example site build produced errors:\n{}",
+        error_lines.join("\n")
+    );
+
+    let output_dir = temp_dir.path().join("output");
+    assert!(output_dir.exists(), "Output directory was not created");
+
+    let html_files: Vec<_> = fs::read_dir(&output_dir)
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "html"))
+        .collect();
+    assert!(
+        html_files.len() > 100,
+        "Expected >100 HTML files, got {}",
+        html_files.len()
+    );
+}
+
+#[test]
+fn test_example_site_template_inheritance() {
+    let (temp_dir, _) = build_example_site();
+    let output_dir = temp_dir.path().join("output");
+
+    let index = fs::read_to_string(output_dir.join("index-1.html")).unwrap();
+
+    // base.html structure
+    assert!(index.contains("<!DOCTYPE html>"));
+    assert!(index.contains("<html"));
+    assert!(index.contains("</html>"));
+    assert!(index.contains("<header"));
+    assert!(index.contains("<footer"));
+
+    // list.html content block rendered
+    assert!(index.contains("content-list"));
+}
+
+#[test]
+fn test_example_site_url_for_function() {
+    let (temp_dir, _) = build_example_site();
+    let output_dir = temp_dir.path().join("output");
+
+    let index = fs::read_to_string(output_dir.join("index-1.html")).unwrap();
+
+    // url_for should generate paths to static files
+    assert!(
+        index.contains("static/marmite.css"),
+        "url_for should resolve static CSS path"
+    );
+    assert!(
+        index.contains("static/marmite.js"),
+        "url_for should resolve static JS path"
+    );
+}
+
+#[test]
+fn test_example_site_content_page_renders() {
+    let (temp_dir, _) = build_example_site();
+    let output_dir = temp_dir.path().join("output");
+
+    let content = fs::read_to_string(output_dir.join("getting-started.html")).unwrap();
+
+    // content.html template rendered with actual content
+    assert!(content.contains("<!DOCTYPE html>"));
+    assert!(content.contains("Getting Started"));
+}
+
+#[test]
+fn test_example_site_date_filter() {
+    let (temp_dir, _) = build_example_site();
+    let output_dir = temp_dir.path().join("output");
+
+    let index = fs::read_to_string(output_dir.join("index-1.html")).unwrap();
+
+    // date filter used in list.html: content.date | date(format='%+')
+    // Should produce datetime attributes on <time> elements
+    assert!(
+        index.contains("dt-published"),
+        "Date filter should produce datetime attributes"
+    );
+}
+
+#[test]
+fn test_example_site_striptags_filter() {
+    let (temp_dir, _) = build_example_site();
+    let output_dir = temp_dir.path().join("output");
+
+    let index = fs::read_to_string(output_dir.join("index-1.html")).unwrap();
+
+    // striptags used in list.html for content excerpts
+    // The excerpt should be plain text (no HTML tags in the p.content-excerpt)
+    assert!(
+        index.contains("content-excerpt"),
+        "List template should render content excerpts"
+    );
+}
+
+#[test]
+fn test_example_site_slice_filter() {
+    let (temp_dir, _) = build_example_site();
+    let output_dir = temp_dir.path().join("output");
+
+    let index = fs::read_to_string(output_dir.join("index-1.html")).unwrap();
+
+    // slice(end=3) used in list.html for tag display
+    // Should render tags without errors
+    assert!(
+        index.contains("content-tags"),
+        "Slice filter should allow tag list rendering"
+    );
+}
+
+#[test]
+fn test_example_site_dot_index_conversion() {
+    let (temp_dir, _) = build_example_site();
+    let output_dir = temp_dir.path().join("output");
+
+    let index = fs::read_to_string(output_dir.join("index-1.html")).unwrap();
+
+    // base.html uses item.0 / item.1 for menu items (converted to item[0]/item[1])
+    // Menu should render without errors
+    assert!(
+        index.contains("header-menu"),
+        "Menu should render (requires item[0]/item[1] conversion)"
+    );
+}
+
+#[test]
+fn test_example_site_starting_with_test() {
+    let (temp_dir, _) = build_example_site();
+    let output_dir = temp_dir.path().join("output");
+
+    let content = fs::read_to_string(output_dir.join("getting-started.html")).unwrap();
+
+    // content_title.html uses: content.html is not starting_with("<h1>")
+    // This should work via the positional-to-keyword conversion
+    assert!(
+        content.contains("</h1>") || content.contains("content-title"),
+        "starting_with test should work for content title rendering"
+    );
+}
+
+#[test]
+fn test_example_site_ignore_missing_includes() {
+    let (temp_dir, _) = build_example_site();
+    let output_dir = temp_dir.path().join("output");
+
+    let content = fs::read_to_string(output_dir.join("getting-started.html")).unwrap();
+
+    // content.html uses {% include "comments.html" ignore missing %}
+    // Should render without errors even when comments template exists but
+    // comments variable may not be defined
+    assert!(
+        content.contains("<!DOCTYPE html>"),
+        "Page should render despite ignore-missing includes"
+    );
+}
+
+#[test]
+fn test_example_site_group_function() {
+    let (temp_dir, _) = build_example_site();
+    let output_dir = temp_dir.path().join("output");
+
+    // group.html is used for tag/author/archive pages
+    // Check that at least some tag pages exist
+    let tag_files: Vec<_> = fs::read_dir(&output_dir)
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .is_some_and(|n| n.starts_with("tag-"))
+        })
+        .collect();
+    assert!(
+        !tag_files.is_empty(),
+        "Tag pages should be generated via group function"
+    );
+}
+
+#[test]
+fn test_example_site_remove_draft_filter() {
+    let (temp_dir, _) = build_example_site();
+    let output_dir = temp_dir.path().join("output");
+
+    // group.html uses: items | remove_draft
+    // If there are group pages, the filter worked
+    let group_pages: Vec<_> = fs::read_dir(&output_dir)
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .is_some_and(|n| n.starts_with("tag-") || n.starts_with("archive-"))
+        })
+        .collect();
+    assert!(
+        !group_pages.is_empty(),
+        "Group pages should render with remove_draft filter"
+    );
+}
+
+#[test]
+fn test_example_site_sitemap() {
+    let (temp_dir, _) = build_example_site();
+    let output_dir = temp_dir.path().join("output");
+
+    let sitemap = fs::read_to_string(output_dir.join("sitemap.xml")).unwrap();
+    assert!(sitemap.contains("<urlset"));
+    assert!(sitemap.contains("<url>"));
+}
+
+#[test]
+fn test_example_site_feeds() {
+    let (temp_dir, _) = build_example_site();
+    let output_dir = temp_dir.path().join("output");
+
+    let rss_files: Vec<_> = fs::read_dir(&output_dir)
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "rss"))
+        .collect();
+    assert!(
+        !rss_files.is_empty(),
+        "At least one RSS feed should be generated"
+    );
+
+    let json_files: Vec<_> = fs::read_dir(&output_dir)
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .is_some_and(|n| n.ends_with(".json") && !n.ends_with("urls.json"))
+        })
+        .collect();
+    assert!(
+        !json_files.is_empty(),
+        "At least one JSON feed should be generated"
+    );
+}
+
+#[test]
+fn test_example_site_pagination() {
+    let (temp_dir, _) = build_example_site();
+    let output_dir = temp_dir.path().join("output");
+
+    // Default pagination is 10, example has more than 10 posts
+    assert!(
+        output_dir.join("index-1.html").exists(),
+        "First pagination page should exist"
+    );
+    assert!(
+        output_dir.join("index-2.html").exists(),
+        "Second pagination page should exist"
+    );
+}
+
+#[test]
+fn test_example_site_optional_chaining_defined_check() {
+    let (temp_dir, _) = build_example_site();
+    let output_dir = temp_dir.path().join("output");
+
+    // content.html has: site.extra.comments.source is defined
+    // This uses optional chaining after preprocessing
+    // Content pages should render without "field is not defined" errors
+    let content = fs::read_to_string(output_dir.join("getting-started.html")).unwrap();
+    assert!(
+        content.contains("<!DOCTYPE html>"),
+        "Pages with deep defined checks should render via optional chaining"
+    );
+}
+
+#[test]
+fn test_example_site_shortcodes_render() {
+    let (temp_dir, _) = build_example_site();
+    let output_dir = temp_dir.path().join("output");
+
+    // shortcodes-demo.md uses various shortcodes
+    if output_dir.join("shortcodes-demo.html").exists() {
+        let content = fs::read_to_string(output_dir.join("shortcodes-demo.html")).unwrap();
+        assert!(
+            content.contains("<!DOCTYPE html>"),
+            "Shortcodes demo page should render"
+        );
+    }
+}

--- a/tests/example_site.rs
+++ b/tests/example_site.rs
@@ -314,9 +314,42 @@ fn test_example_site_shortcodes_render() {
     // shortcodes-demo.md uses various shortcodes
     if output_dir.join("shortcodes-demo.html").exists() {
         let content = fs::read_to_string(output_dir.join("shortcodes-demo.html")).unwrap();
+
+        // No shortcode error divs should be present
         assert!(
-            content.contains("<!DOCTYPE html>"),
-            "Shortcodes demo page should render"
+            !content.contains("shortcode-error"),
+            "Shortcodes demo should have no rendering errors"
+        );
+
+        // YouTube shortcode should render iframes
+        assert!(
+            content.contains("<iframe") || content.contains("youtube"),
+            "YouTube shortcode should render"
         );
     }
+}
+
+#[test]
+fn test_example_site_no_shortcode_errors() {
+    let (temp_dir, _) = build_example_site();
+    let output_dir = temp_dir.path().join("output");
+
+    // No page should contain shortcode-error divs
+    let pages_with_errors: Vec<String> = fs::read_dir(&output_dir)
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "html"))
+        .filter(|e| {
+            fs::read_to_string(e.path())
+                .unwrap_or_default()
+                .contains("shortcode-error")
+        })
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+
+    assert!(
+        pages_with_errors.is_empty(),
+        "Pages with shortcode errors: {:?}",
+        pages_with_errors
+    );
 }


### PR DESCRIPTION
## Summary

Tera 2.0 was released on 2026-06-26 with significant breaking changes. This PR migrates the entire marmite codebase to the new API while keeping all existing templates and shortcodes fully backward-compatible - no template files were modified.

Supersedes #469 (dependabot bump) by including the dependency update plus all required code changes.

## What changed in Tera 2.0

Tera 2.0 redesigns the Rust API, removes macros in favor of components, drops several built-in filters, enforces strict template validation at load time, and tightens undefined variable access. The [migration guide](https://github.com/Keats/tera/blob/master/MIGRATION.md) covers the full list.

## Rust API changes

- **Filter/Function traits**: redesigned with generics and new `call()` signatures taking `Kwargs` + `&State` instead of `&HashMap<String, Value>`
- **Value type**: no longer re-exports `serde_json::Value` - custom type with different constructors (`Value::from()` instead of `Value::String()`, `Value::none()` instead of `Value::Null`)
- **Error API**: `Error::msg()` renamed to `Error::message()`, `tera::Result` renamed to `TeraResult`
- **Template loading**: `tera.extend()` replaced - `register_from()` only copies filters/functions, not templates. `add_raw_template()` now validates all referenced functions/filters/includes exist at load time
- **Other**: `get_template()` now private, `render_str()` requires `autoescape` param, `autoescape_on(vec![])` needs type annotation

Added `UrlFor::resolve()` and `DisplayName::resolve()` helper methods so these structs can be called directly from Rust without constructing Tera-internal types.

## Compatibility shims for removed filters

Registered custom implementations for filters that Tera 2.0 dropped or moved to `tera-contrib`:

| Filter | Status in Tera 2.0 |
|--------|-------------------|
| `date` | Moved to tera-contrib |
| `striptags` | Removed |
| `trim_start_matches` | Renamed to `trim_start` |
| `slice` | Removed |

## Template preprocessing layer

To keep all existing templates and shortcodes working without modification, added a preprocessing step that transforms Tera 1.x syntax to 2.0 equivalents before loading:

| Tera 1.x syntax | Tera 2.0 equivalent |
|-----------------|-------------------|
| `{% include "x" ignore missing %}` | `{% include "x" %}` + empty template fallback |
| `item.0` (numeric dot-index) | `item[0]` (bracket notation) |
| `is starting_with("x")` | `is starting_with(pat="x")` |
| `a.b.c is defined` | `a?.b?.c is defined` (optional chaining) |
| `{{ var.field \| default(...) }}` | `{{ var?.field \| default(...) }}` |
| `{% macro name() %}` | `{% component name() %}` (shortcodes) |
| `{% import "x" as sc %}{{ sc::name() }}` | `{{ <name /> }}` (shortcodes) |

## Template loading restructure

Tera 2.0's strict validation at `add_raw_template()` time required restructuring `initialize_tera()` into three phases:

1. **Collect** all template content (user templates from disk + embedded defaults)
2. **Pre-register** empty templates for `ignore missing` include targets
3. **Load** all templates in a single batch via `add_raw_templates()`

Removed the `EMBEDDED_TERA` static since Tera 2.0 validates function/filter references at template-add time, making pre-compilation without registered functions impossible.

## Test plan

- [x] `cargo fmt` - clean
- [x] `cargo clippy` - clean
- [x] 283 unit tests pass
- [x] 35 integration tests pass (across 7 test files)
- [x] Example site generates 210 HTML files with 0 errors
- [x] No template or shortcode files modified